### PR TITLE
feat: add configurable proxy scopes and GPT-6 Astra

### DIFF
--- a/README.i18n.yaml
+++ b/README.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   git hash-object README.md README.zh.md
-README.md: 4cc804b94d0ddc9ca5b120558d7a3b864ec8a9a5
-README.zh.md: e40962d6fae66a42c8d15135cfbac8046abeadae
+README.md: 0059d44b6bbee67b3aa9ea5f0be330e0515781a5
+README.zh.md: 38ee466d25680cb443ee2955d69a85e14de09d8e

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Use a ChatGPT subscription in [DeepSeek Harness](https://github.com/deepseek-ai/
 - an `imagegen` tool backed by `gpt-image-2`, with workspace or conversation reference images and automatic workspace output
 - browser image input through dsh's existing paste and drop controls
 - a per-conversation Fast Mode switch and compact weekly quota indicator in the Web composer
+- a three-scope HTTP(S) proxy control for Codex-only or process-wide routing
 
 ChatGPT subscription authentication and usage-based OpenAI API access are different products. This plugin uses the ChatGPT Codex backend only; it does not turn a subscription into a general-purpose OpenAI API credential.
 
@@ -86,6 +87,16 @@ The initial value can also be seeded in exact tokens:
 
 This mirrors Codex CLI's `model_context_window` concept on the Harness side; no context-window field is sent to the Responses endpoint. The resolved capacity drives dsh's context meter, overflow classification, output-token clamping, and automatic-compaction threshold. A smaller value compacts earlier. A larger value does not increase the backend model's real capacity, so unsupported values can still end in a provider overflow error.
 
+## Network proxy
+
+Open **Settings → OpenAI Codex → Network proxy** to select one of three scopes:
+
+- **Follow dsh** leaves networking untouched. Codex inherits any process-wide proxy configured when dsh started.
+- **Codex only** injects the selected proxy into Codex model SSE requests, native compaction, standalone search, image generation, and quota reads. OAuth token refresh and WebSocket transport still follow the process policy.
+- **All dsh** applies the proxy process-wide, including OAuth; requests from other plugins are affected too. Turning it off restores the policy that was active before this plugin overrode it.
+
+The URL accepts `http://` and `https://` proxies. Leave it blank to use `DSH_CODEX_PROXY`, then the standard `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, and `NO_PROXY` environment variables. The default mode is **Follow dsh**, so installing the plugin never silently changes the process dispatcher.
+
 ## Images
 
 Image support uses dsh's durable attachment path:
@@ -148,7 +159,7 @@ Keeping the stores separate prevents two clients from racing the same rotating r
 
 ## Compatibility notes
 
-- This branch targets the published DSH `0.1.1-rc.2` plugin surfaces and remains runtime-compatible with the in-development `0.1.2-alpha.2` settings API. It uses `@earendil-works/pi-ai` `0.84.4` and migrates earlier pi-ai replay envelopes while reading history so existing reasoning/tool metadata remains usable after upgrades.
+- This branch targets the coherent published DSH `0.1.1-rc.2` plugin surfaces. Process-wide proxy mode composes with the official `dsh-http-proxy` library when a newer Harness provides it and uses a reversible compatibility dispatcher otherwise. It uses `@earendil-works/pi-ai` `0.84.4` and migrates earlier pi-ai replay envelopes while reading history so existing reasoning/tool metadata remains usable after upgrades.
 - The plugin runs on released dsh plugin surfaces and does not require a modified Harness checkout. It can generate attachments and save local output when installed alone.
 - ChatGPT plan eligibility, model access, quotas, and backend behavior are controlled by OpenAI and may change.
 - The Codex endpoint does not enforce the ordinary Responses `max_output_tokens` field. Compaction works, but its configured summary cap cannot be imposed server-side on this route.

--- a/README.zh.md
+++ b/README.zh.md
@@ -15,6 +15,7 @@
 - 由 `gpt-image-2` 执行的 `imagegen` 工具，支持工作区／会话参考图和自动工作区输出
 - 复用 dsh Web 输入框的粘贴和拖放图片能力
 - 在 Web 输入框提供按会话生效的 Fast Mode 开关与紧凑的每周额度指示器
+- 可选择仅 Codex 或整个进程范围的三态 HTTP(S) 代理设置
 
 ChatGPT 订阅认证与按量计费的 OpenAI API 是不同产品。本插件只使用 ChatGPT Codex 后端，不会把订阅转换成通用 OpenAI API 凭据。
 
@@ -86,6 +87,16 @@ bundle 会为新建 agent 选择 `openai-codex` / `gpt-5.6-sol`，并选择 Code
 
 该功能在 Harness 一侧对应 Codex CLI 的 `model_context_window` 概念，不会向 Responses 端点发送上下文窗口字段。解析后的容量会直接控制 dsh 的上下文用量分母、溢出判断、输出 token 收缩和自动压缩阈值；较小的值会更早压缩。较大的值不会提高后端模型的真实容量，模型不支持时仍可能返回上下文溢出错误。
 
+## 网络代理
+
+打开 **设置 → OpenAI Codex → 网络代理**，可以选择三种范围：
+
+- **跟随 dsh** 不由插件覆盖网络设置；Codex 继承 dsh 启动时已经配置的进程级代理。
+- **仅 Codex** 把所选代理注入 Codex 模型 SSE 请求、原生压缩、独立搜索、生图与额度读取；OAuth Token 刷新和 WebSocket 仍遵循进程策略。
+- **整个 dsh** 把代理应用到整个进程，并覆盖 OAuth；其他插件的请求也会受影响。关闭后会恢复插件覆盖前的宿主策略。
+
+代理 URL 支持 `http://` 与 `https://`。留空时依次使用 `DSH_CODEX_PROXY`，以及标准的 `HTTP_PROXY`、`HTTPS_PROXY`、`ALL_PROXY` 与 `NO_PROXY` 环境变量。默认模式是 **跟随 dsh**，因此安装插件不会静默改变整个进程的 dispatcher。
+
 ## 图片
 
 图片功能使用 dsh 的持久附件路径：
@@ -148,7 +159,7 @@ dsh 登录与 Codex CLI／Desktop 相互独立：
 
 ## 兼容性说明
 
-- 本分支面向已发布的 DSH `0.1.1-rc.2` 插件表层，并兼容开发中的 `0.1.2-alpha.2` settings API；同时使用 `@earendil-works/pi-ai` `0.84.4`。adapter 会在读取历史时迁移旧版 pi-ai replay envelope，因此升级后已有 reasoning／tool 元数据仍可继续使用。
+- 本分支面向成套发布的 DSH `0.1.1-rc.2` 插件表层。较新 Harness 提供正式 `dsh-http-proxy` 库时，全局代理模式会与其组合；旧版则使用可恢复的兼容 dispatcher。同时使用 `@earendil-works/pi-ai` `0.84.4`，adapter 会在读取历史时迁移旧版 pi-ai replay envelope，因此升级后已有 reasoning／tool 元数据仍可继续使用。
 - 插件只使用已发布的 dsh 插件表层，不要求修改版 Harness checkout。单独安装时即可生成附件并保存本地输出。
 - ChatGPT 套餐资格、模型权限、配额及后端行为由 OpenAI 控制，可能发生变化。
 - Codex 端点不执行普通 Responses 的 `max_output_tokens` 字段。压缩可以工作，但该路由无法在服务端落实配置的摘要上限。

--- a/package.json
+++ b/package.json
@@ -68,6 +68,9 @@
       "platform": "web"
     }
   },
+  "dependencies": {
+    "undici": "8.10.0"
+  },
   "peerDependencies": {
     "@earendil-works/pi-ai": "^0.84.4",
     "@deepseek-ai/cordis": "^4.0.1-rc.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,10 @@ overrides:
 importers:
 
   .:
+    dependencies:
+      undici:
+        specifier: 8.10.0
+        version: 8.10.0
     devDependencies:
       '@deepseek-ai/cordis':
         specifier: ^4.0.1
@@ -2352,6 +2356,10 @@ packages:
     resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
+  undici@8.10.0:
+    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
+    engines: {node: '>=22.19.0'}
+
   use-sync-external-store@1.2.0:
     resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}
     peerDependencies:
@@ -4652,6 +4660,8 @@ snapshots:
   undici-types@6.21.0: {}
 
   undici@7.29.0: {}
+
+  undici@8.10.0: {}
 
   use-sync-external-store@1.2.0(react@18.3.1):
     dependencies:

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -4,6 +4,7 @@ import { createModels } from "@earendil-works/pi-ai";
 import type {
   AuthContext,
   Context as PiContext,
+  FetchFunction,
   MutableModels,
   Provider,
   SimpleStreamOptions,
@@ -311,12 +312,25 @@ function withOpenAICodexContextWindow(
 
 function requestProvider(
   provider: Provider,
-  fastMode?: FastModeRegistry
+  fastMode?: FastModeRegistry,
+  requestFetch?: FetchFunction
 ): Provider {
+  const configured = withOpenAICodexFastMode(provider, fastMode);
+  const streamSimple = configured.streamSimple;
   return {
-    ...withOpenAICodexFastMode(provider, fastMode),
+    ...configured,
+    streamSimple(model, context, options) {
+      return streamSimple.call(configured, model, context, {
+        ...options,
+        ...(options?.fetch !== undefined
+          ? {}
+          : requestFetch === undefined
+            ? {}
+            : { fetch: requestFetch }),
+      });
+    },
     auth: {
-      ...provider.auth,
+      ...configured.auth,
       apiKey: {
         name: "OpenAI Codex OAuth bearer token",
         async resolve({ credential }) {
@@ -398,10 +412,18 @@ export function createOpenAICodexAdapter(
   fastMode?: FastModeRegistry,
   visibleModelIds?: () => readonly string[],
   contextWindow?: () => number | null | undefined,
-  overrideSparkContextWindow?: () => boolean | undefined
+  overrideSparkContextWindow?: () => boolean | undefined,
+  requestFetch?: FetchFunction
 ): PiAiAdapter {
-  const provider = requestProvider(openaiCodexProvider(), fastMode);
-  const responses = new OpenAICodexResponseRuntime(responsePreferences);
+  const provider = requestProvider(
+    openaiCodexProvider(),
+    fastMode,
+    requestFetch
+  );
+  const responses = new OpenAICodexResponseRuntime(
+    responsePreferences,
+    requestFetch
+  );
   const unset = Symbol("unset context window");
   let resolvedContextWindow: number | null | undefined | typeof unset = unset;
   let resolvedOverrideSparkContextWindow: boolean | undefined;

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -33,10 +33,73 @@ import type {
 import type { FastModeRegistry } from "./fast-mode.ts";
 
 const GPT_5_3_CODEX_SPARK = "gpt-5.3-codex-spark";
+const GPT_6_ASTRA = "gpt-6-astra";
+
+const OPENAI_CODEX_MODEL_ORDER = new Map<string, number>(
+  [
+    GPT_6_ASTRA,
+    "gpt-5.6-luna",
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    GPT_5_3_CODEX_SPARK,
+    "gpt-5.5",
+    "gpt-5.4",
+    "gpt-5.4-mini",
+  ].map((id, index) => [id, index])
+);
+
+/** Add Codex models released ahead of pi-ai's generated catalog, then order newest first. */
+function withOpenAICodexModelAdditions(provider: Provider): Provider {
+  const getModels = provider.getModels;
+  return {
+    ...provider,
+    getModels() {
+      const models = [...getModels.call(provider)];
+      if (!models.some((model) => model.id === GPT_6_ASTRA)) {
+        const template =
+          models.find((model) => model.id === "gpt-5.6-sol") ?? models[0];
+        if (template !== undefined) {
+          models.push({
+            ...template,
+            id: GPT_6_ASTRA,
+            name: "GPT-6 Astra",
+            contextWindow: 1_050_000,
+            maxTokens: 128_000,
+            cost: {
+              input: 10,
+              output: 50,
+              cacheRead: 1,
+              cacheWrite: 12.5,
+              tiers: [
+                {
+                  inputTokensAbove: 272_000,
+                  input: 20,
+                  output: 75,
+                  cacheRead: 2,
+                  cacheWrite: 25,
+                },
+              ],
+            },
+          });
+        }
+      }
+      return models
+        .map((model, index) => ({ model, index }))
+        .sort((left, right) => {
+          const leftOrder =
+            OPENAI_CODEX_MODEL_ORDER.get(left.model.id) ?? Number.MAX_SAFE_INTEGER;
+          const rightOrder =
+            OPENAI_CODEX_MODEL_ORDER.get(right.model.id) ?? Number.MAX_SAFE_INTEGER;
+          return leftOrder - rightOrder || left.index - right.index;
+        })
+        .map(({ model }) => model);
+    },
+  };
+}
 
 /** Return a detached copy of the complete pi-ai Codex model catalog. */
 export function openAICodexModelCatalog(): readonly ModelCatalogEntry[] {
-  return openaiCodexProvider()
+  return withOpenAICodexModelAdditions(openaiCodexProvider())
     .getModels()
     .map((model) => ({
       id: model.id,
@@ -416,7 +479,7 @@ export function createOpenAICodexAdapter(
   requestFetch?: FetchFunction
 ): PiAiAdapter {
   const provider = requestProvider(
-    openaiCodexProvider(),
+    withOpenAICodexModelAdditions(openaiCodexProvider()),
     fastMode,
     requestFetch
   );

--- a/src/auth-routes.ts
+++ b/src/auth-routes.ts
@@ -36,6 +36,7 @@ import type {
   ModelCatalogPreferences,
   ResponseApiPreferences,
 } from "./tool-policy.ts";
+import type { ProxyPreferences } from "./proxy.ts";
 
 export {
   OPENAI_CODEX_AUTH_LOGIN_PATH,
@@ -56,6 +57,9 @@ export const OPENAI_CODEX_MODEL_CATALOG_SETTINGS_PATH =
 /** Plugin-owned client-side context capacity endpoint consumed by its browser half. */
 export const OPENAI_CODEX_CONTEXT_WINDOW_SETTINGS_PATH =
   "/plugins/dsh-openai-codex/context-window";
+/** Plugin-owned proxy preference endpoint consumed by its browser half. */
+export const OPENAI_CODEX_PROXY_SETTINGS_PATH =
+  "/plugins/dsh-openai-codex/proxy";
 
 /** Maximum time a browser request waits for the provider's authorization URL. */
 export const OPENAI_CODEX_AUTH_URL_TIMEOUT_MS = 30_000;
@@ -90,6 +94,8 @@ export const OPENAI_CODEX_SIGN_IN_TIMEOUT_MS = 10 * 60 * 1000;
 export interface OpenAICodexWebAuthOptions {
   challengeTimeoutMs?: number;
   signInTimeoutMs?: number;
+  requestFetch?: typeof globalThis.fetch;
+  beforeNetworkRequest?: () => Promise<void>;
 }
 
 /** Redact provider diagnostics before they cross to the browser. */
@@ -135,6 +141,8 @@ export class OpenAICodexWebAuth {
   private challengeTimer: ReturnType<typeof setTimeout> | undefined;
   private readonly challengeTimeoutMs: number;
   private readonly signInTimeoutMs: number;
+  private readonly requestFetch: typeof globalThis.fetch;
+  private readonly beforeNetworkRequest: (() => Promise<void>) | undefined;
 
   constructor(
     private readonly store: OpenAICodexCredentialStore,
@@ -144,6 +152,8 @@ export class OpenAICodexWebAuth {
       options.challengeTimeoutMs ?? OPENAI_CODEX_AUTH_URL_TIMEOUT_MS;
     this.signInTimeoutMs =
       options.signInTimeoutMs ?? OPENAI_CODEX_SIGN_IN_TIMEOUT_MS;
+    this.requestFetch = options.requestFetch ?? globalThis.fetch;
+    this.beforeNetworkRequest = options.beforeNetworkRequest;
     if (
       !Number.isFinite(this.challengeTimeoutMs) ||
       this.challengeTimeoutMs <= 0
@@ -211,18 +221,24 @@ export class OpenAICodexWebAuth {
       );
     }, this.signInTimeoutMs);
     signInTimer.unref();
-    this.operation = loginOpenAICodex(
-      {
-        signal: cancellation.signal,
-        prompt: (prompt) =>
-          prompt.type === "select"
-            ? Promise.resolve("browser")
-            : waitForPromptAbort(prompt),
-        notify: (event) => {
-          this.onEvent(event);
-        },
-      },
-      this.store
+    const login = (): Promise<void> =>
+      loginOpenAICodex(
+          {
+            signal: cancellation.signal,
+            prompt: (prompt) =>
+              prompt.type === "select"
+                ? Promise.resolve("browser")
+                : waitForPromptAbort(prompt),
+            notify: (event) => {
+              this.onEvent(event);
+            },
+          },
+          this.store
+        );
+    this.operation = (
+      this.beforeNetworkRequest === undefined
+        ? login()
+        : this.beforeNetworkRequest().then(login)
     )
       .then(
         async () => {
@@ -287,12 +303,13 @@ export class OpenAICodexWebAuth {
   }
 
   private async readStoredStatus(): Promise<OpenAICodexWebAuthStatus> {
+    await this.beforeNetworkRequest?.();
     const stored = await openAICodexAuthStatus(this.store);
     if (!stored.authenticated) return { status: "signed-out" };
     try {
       return {
         status: "signed-in",
-        usage: await readOpenAICodexRateLimits(this.store),
+        usage: await readOpenAICodexRateLimits(this.store, this.requestFetch),
       };
     } catch (error: unknown) {
       if (isOpenAICodexReauthRequiredError(error)) {
@@ -672,15 +689,64 @@ function modelCatalogPatch(
   return { models };
 }
 
+function proxyPreferencePatch(
+  value: Record<string, unknown>
+): Partial<ProxyPreferences> {
+  const allowed = new Set<keyof ProxyPreferences>([
+    "proxyMode",
+    "proxyUrl",
+  ]);
+  if (
+    Object.keys(value).some(
+      (key) => !allowed.has(key as keyof ProxyPreferences)
+    )
+  ) {
+    throw new TypeError("request contains an unknown proxy setting");
+  }
+  const patch: Partial<ProxyPreferences> = {};
+  const proxyMode = value["proxyMode"];
+  if (proxyMode !== undefined) {
+    if (
+      proxyMode !== "off" &&
+      proxyMode !== "scoped" &&
+      proxyMode !== "global"
+    ) {
+      throw new TypeError("proxyMode must be off, scoped, or global");
+    }
+    patch.proxyMode = proxyMode;
+  }
+  const proxyUrl = value["proxyUrl"];
+  if (proxyUrl !== undefined) {
+    if (typeof proxyUrl !== "string") {
+      throw new TypeError("proxyUrl must be a string");
+    }
+    patch.proxyUrl = proxyUrl;
+  }
+  return patch;
+}
+
+interface ProxySettingsController {
+  proxyPreferences(): ProxyPreferences;
+  updateProxyPreferences(
+    patch: Partial<ProxyPreferences>
+  ): Promise<ProxyPreferences>;
+}
+
 /** Register the plugin-owned OAuth routes when the Web server is composed. */
 export function registerOpenAICodexAuthRoutes(
   ctx: Context,
   store: OpenAICodexCredentialStore,
   trustedOriginsOverride?: OpenAICodexTrustedOriginsStore,
   fastModeOverride?: FastModeRegistry,
-  imageTools?: ImageToolPolicy
+  imageTools?: ImageToolPolicy,
+  proxySettings?: ProxySettingsController,
+  requestFetch?: typeof globalThis.fetch,
+  beforeNetworkRequest?: () => Promise<void>
 ): void {
-  const auth = new OpenAICodexWebAuth(store);
+  const auth = new OpenAICodexWebAuth(store, {
+    ...(requestFetch === undefined ? {} : { requestFetch }),
+    ...(beforeNetworkRequest === undefined ? {} : { beforeNetworkRequest }),
+  });
   const storedFilename = (
     store as OpenAICodexCredentialStore & { filename?: unknown }
   ).filename;
@@ -864,6 +930,34 @@ export function registerOpenAICodexAuthRoutes(
                     200,
                     await imageTools.updateModelCatalog(
                       modelCatalogPatch(await readSettingsBody(req))
+                    )
+                  );
+                } catch (error: unknown) {
+                  return json(res, 400, { error: safeMessage(error) });
+                }
+              },
+            }),
+          ]),
+      ...(proxySettings === undefined
+        ? []
+        : [
+            ctx.webServer.register({
+              kind: "exact",
+              path: OPENAI_CODEX_PROXY_SETTINGS_PATH,
+              handler: async (req, res) => {
+                if (!(await authorize(req, res))) return;
+                if (req.method === "GET") {
+                  return json(res, 200, proxySettings.proxyPreferences());
+                }
+                if (req.method !== "POST") {
+                  return json(res, 405, { error: "method not allowed" });
+                }
+                try {
+                  return json(
+                    res,
+                    200,
+                    await proxySettings.updateProxyPreferences(
+                      proxyPreferencePatch(await readSettingsBody(req))
                     )
                   );
                 } catch (error: unknown) {

--- a/src/client/OpenAICodexSettings.tsx
+++ b/src/client/OpenAICodexSettings.tsx
@@ -247,25 +247,26 @@ const numberInputStyle: CSSProperties = {
 const proxyModeStyle: CSSProperties = {
   display: "grid",
   gridTemplateColumns: "repeat(3, minmax(0, 1fr))",
-  gap: 4,
-  padding: 4,
+  overflow: "hidden",
   border: "1px solid var(--dsw-alias-border-l2)",
-  borderRadius: 12,
-  background: "var(--dsw-alias-bg-layer-2, rgba(0, 0, 0, 0.06))",
+  borderRadius: 999,
+  background: "var(--dsw-alias-bg-layer-1)",
+  boxShadow: "0 1px 2px rgba(0, 0, 0, 0.05)",
 };
 const proxyModeButtonStyle: CSSProperties = {
+  boxSizing: "border-box",
   minWidth: 0,
-  minHeight: 38,
-  padding: "7px 10px",
-  border: "1px solid transparent",
-  borderRadius: 9,
+  minHeight: 40,
+  padding: "8px 12px",
+  border: 0,
+  borderRadius: 0,
   background: "transparent",
   color: "var(--dsw-alias-label-secondary)",
   font: "inherit",
   fontSize: 13,
-  fontWeight: 500,
+  fontWeight: 600,
   cursor: "pointer",
-  transition: "background 120ms ease, color 120ms ease, border 120ms ease",
+  transition: "background 140ms ease, color 140ms ease",
 };
 const proxyInputStyle: CSSProperties = {
   ...numberInputStyle,
@@ -353,8 +354,32 @@ function ProxyModeControl({
     { value: "global", label: "proxyModeGlobal" },
   ];
   return (
-    <div style={proxyModeStyle} role="radiogroup" aria-label={t("proxyMode")}>
-      {options.map((option) => {
+    <div
+      style={proxyModeStyle}
+      role="radiogroup"
+      aria-label={t("proxyMode")}
+      onKeyDown={(event) => {
+        if (
+          event.key !== "ArrowLeft" &&
+          event.key !== "ArrowRight" &&
+          event.key !== "ArrowUp" &&
+          event.key !== "ArrowDown"
+        ) {
+          return;
+        }
+        event.preventDefault();
+        const currentIndex = options.findIndex((option) => option.value === value);
+        const direction =
+          event.key === "ArrowRight" || event.key === "ArrowDown" ? 1 : -1;
+        const nextIndex =
+          (currentIndex + direction + options.length) % options.length;
+        const nextOption = options[nextIndex];
+        if (nextOption === undefined) return;
+        onChange(nextOption.value);
+        const buttons = event.currentTarget.querySelectorAll("button");
+        buttons.item(nextIndex).focus();
+      }}>
+      {options.map((option, index) => {
         const selected = value === option.value;
         return (
           <button
@@ -366,12 +391,13 @@ function ProxyModeControl({
             style={{
               ...proxyModeButtonStyle,
               opacity: disabled ? 0.55 : 1,
+              ...(index === 0
+                ? {}
+                : { borderLeft: "1px solid var(--dsw-alias-border-l2)" }),
               ...(selected
                 ? {
-                    borderColor: "var(--dsw-alias-border-l2)",
-                    background: "var(--dsw-alias-bg-layer-1)",
-                    color: "var(--dsw-alias-label-primary)",
-                    boxShadow: "0 1px 3px rgba(0, 0, 0, 0.08)",
+                    background: "var(--dsw-alias-button-primary-fill)",
+                    color: "var(--dsw-alias-label-primary-foreground)",
                   }
                 : {}),
             }}

--- a/src/client/OpenAICodexSettings.tsx
+++ b/src/client/OpenAICodexSettings.tsx
@@ -11,6 +11,10 @@ import type {
   ResponseApiPreferences,
 } from "../tool-policy.ts";
 import type { OpenAICodexSettingsKey } from "./locales.ts";
+import type {
+  OpenAICodexProxyMode,
+  ProxyPreferences,
+} from "../proxy.ts";
 
 const STATUS_PATH = "/plugins/dsh-openai-codex/auth/status";
 const LOGIN_PATH = "/plugins/dsh-openai-codex/auth/login";
@@ -19,6 +23,7 @@ const IMAGE_TOOLS_PATH = "/plugins/dsh-openai-codex/image-tools";
 const RESPONSE_API_PATH = "/plugins/dsh-openai-codex/response-api";
 const MODEL_CATALOG_PATH = "/plugins/dsh-openai-codex/models";
 const CONTEXT_WINDOW_PATH = "/plugins/dsh-openai-codex/context-window";
+const PROXY_PATH = "/plugins/dsh-openai-codex/proxy";
 const POLL_INTERVAL_MS = 1_000;
 const USAGE_POLL_INTERVAL_MS = 60_000;
 
@@ -239,6 +244,36 @@ const numberInputStyle: CSSProperties = {
   font: "inherit",
   fontSize: 14,
 };
+const proxyModeStyle: CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "repeat(3, minmax(0, 1fr))",
+  gap: 4,
+  padding: 4,
+  border: "1px solid var(--dsw-alias-border-l2)",
+  borderRadius: 12,
+  background: "var(--dsw-alias-bg-layer-2, rgba(0, 0, 0, 0.06))",
+};
+const proxyModeButtonStyle: CSSProperties = {
+  minWidth: 0,
+  minHeight: 38,
+  padding: "7px 10px",
+  border: "1px solid transparent",
+  borderRadius: 9,
+  background: "transparent",
+  color: "var(--dsw-alias-label-secondary)",
+  font: "inherit",
+  fontSize: 13,
+  fontWeight: 500,
+  cursor: "pointer",
+  transition: "background 120ms ease, color 120ms ease, border 120ms ease",
+};
+const proxyInputStyle: CSSProperties = {
+  ...numberInputStyle,
+  width: "auto",
+  flex: "1 1 320px",
+  fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+  fontSize: 13,
+};
 const commandStyle: CSSProperties = {
   margin: 0,
   padding: "10px 12px",
@@ -295,6 +330,59 @@ function PreferenceToggle({
         }}
       />
     </button>
+  );
+}
+
+function ProxyModeControl({
+  value,
+  disabled,
+  onChange,
+  t,
+}: {
+  value: OpenAICodexProxyMode;
+  disabled: boolean;
+  onChange(value: OpenAICodexProxyMode): void;
+  t: OpenAICodexSettingsInjected["t"];
+}) {
+  const options: Array<{
+    value: OpenAICodexProxyMode;
+    label: OpenAICodexSettingsKey;
+  }> = [
+    { value: "off", label: "proxyModeOff" },
+    { value: "scoped", label: "proxyModeScoped" },
+    { value: "global", label: "proxyModeGlobal" },
+  ];
+  return (
+    <div style={proxyModeStyle} role="radiogroup" aria-label={t("proxyMode")}>
+      {options.map((option) => {
+        const selected = value === option.value;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            disabled={disabled}
+            style={{
+              ...proxyModeButtonStyle,
+              opacity: disabled ? 0.55 : 1,
+              ...(selected
+                ? {
+                    borderColor: "var(--dsw-alias-border-l2)",
+                    background: "var(--dsw-alias-bg-layer-1)",
+                    color: "var(--dsw-alias-label-primary)",
+                    boxShadow: "0 1px 3px rgba(0, 0, 0, 0.08)",
+                  }
+                : {}),
+            }}
+            onClick={() => {
+              onChange(option.value);
+            }}>
+            {t(option.label)}
+          </button>
+        );
+      })}
+    </div>
   );
 }
 
@@ -602,6 +690,11 @@ export function OpenAICodexSettings({ t }: OpenAICodexSettingsProps) {
   const [contextWindowError, setContextWindowError] = useState<
     string | undefined
   >();
+  const [proxy, setProxy] = useState<ProxyPreferences | undefined>();
+  const [proxyDraft, setProxyDraft] = useState("");
+  const [proxyBusy, setProxyBusy] = useState(false);
+  const [proxyError, setProxyError] = useState<string | undefined>();
+  const [proxySaved, setProxySaved] = useState(false);
   const trustedOriginCommand = `dsh plugin --profile web exec dsh-openai-codex trust-origin ${window.location.origin}`;
 
   const refresh = useCallback(async () => {
@@ -666,6 +759,18 @@ export function OpenAICodexSettings({ t }: OpenAICodexSettingsProps) {
       },
       () => {
         setContextWindowError(t("contextWindowSettingsFailed"));
+      }
+    );
+  }, [t]);
+  useEffect(() => {
+    void jsonRequest<ProxyPreferences>(PROXY_PATH).then(
+      (value) => {
+        setProxy(value);
+        setProxyDraft(value.proxyUrl);
+        setProxyError(undefined);
+      },
+      () => {
+        setProxyError(t("proxySettingsFailed"));
       }
     );
   }, [t]);
@@ -834,6 +939,30 @@ export function OpenAICodexSettings({ t }: OpenAICodexSettingsProps) {
     }
   };
 
+  const updateProxy = async (
+    patch: Partial<ProxyPreferences>
+  ): Promise<void> => {
+    setProxyBusy(true);
+    setProxyError(undefined);
+    setProxySaved(false);
+    try {
+      const saved = await jsonRequest<ProxyPreferences>(
+        PROXY_PATH,
+        "POST",
+        patch
+      );
+      setProxy(saved);
+      if (patch.proxyUrl !== undefined) setProxyDraft(saved.proxyUrl);
+      setProxySaved(true);
+    } catch (error: unknown) {
+      setProxyError(
+        error instanceof Error ? error.message : t("proxySettingsFailed")
+      );
+    } finally {
+      setProxyBusy(false);
+    }
+  };
+
   const copyTrustedOriginCommand = async (): Promise<void> => {
     setCopyFailed(false);
     try {
@@ -937,6 +1066,62 @@ export function OpenAICodexSettings({ t }: OpenAICodexSettingsProps) {
             t={t}
           />
         ) : null}
+      </div>
+      <div style={cardStyle}>
+        <div>
+          <h3 style={quotaTitleStyle}>{t("proxy")}</h3>
+          <p style={{ ...bodyStyle, marginTop: 5 }}>{t("proxyIntro")}</p>
+        </div>
+        <ProxyModeControl
+          value={proxy?.proxyMode ?? "off"}
+          disabled={proxy === undefined || proxyBusy}
+          onChange={(proxyMode) => {
+            void updateProxy({ proxyMode });
+          }}
+          t={t}
+        />
+        <p style={bodyStyle}>
+          {t(
+            proxy?.proxyMode === "scoped"
+              ? "proxyModeScopedHint"
+              : proxy?.proxyMode === "global"
+                ? "proxyModeGlobalHint"
+                : "proxyModeOffHint"
+          )}
+        </p>
+        <div style={{ ...rowStyle, justifyContent: "flex-start" }}>
+          <label htmlFor="openai-codex-proxy-url" style={statusStyle}>
+            {t("proxyUrl")}
+          </label>
+          <input
+            id="openai-codex-proxy-url"
+            type="url"
+            inputMode="url"
+            spellCheck={false}
+            placeholder={t("proxyUrlPlaceholder")}
+            value={proxyDraft}
+            disabled={proxy === undefined || proxyBusy}
+            style={proxyInputStyle}
+            onChange={(event) => {
+              setProxyDraft(event.currentTarget.value);
+              setProxySaved(false);
+            }}
+          />
+          <button
+            type="button"
+            style={primaryButtonStyle}
+            disabled={proxy === undefined || proxyBusy}
+            onClick={() => {
+              void updateProxy({ proxyUrl: proxyDraft });
+            }}>
+            {proxyBusy ? t("working") : t("proxySave")}
+          </button>
+        </div>
+        <p style={bodyStyle}>{t("proxyUrlHint")}</p>
+        {proxyError === undefined ? null : (
+          <p style={errorStyle}>{proxyError}</p>
+        )}
+        {proxySaved ? <p style={bodyStyle}>{t("proxySaved")}</p> : null}
       </div>
       <div style={cardStyle}>
         <div>

--- a/src/client/locales.ts
+++ b/src/client/locales.ts
@@ -45,6 +45,26 @@ export const en = {
   remoteOriginCopy: "Copy command",
   remoteOriginCopied: "Copied",
   remoteOriginCopyFailed: "Could not copy the command.",
+  proxy: "Network proxy",
+  proxyIntro:
+    "Choose how this plugin applies a proxy. Changes take effect without restarting dsh.",
+  proxyMode: "Proxy scope",
+  proxyModeOff: "Follow dsh",
+  proxyModeScoped: "Codex only",
+  proxyModeGlobal: "All dsh",
+  proxyModeOffHint:
+    "The plugin does not override networking. Codex still follows any process-wide proxy configured when dsh started.",
+  proxyModeScopedHint:
+    "Only Codex HTTP requests after authentication use this proxy. OAuth token refresh and WebSocket transport continue to follow dsh networking.",
+  proxyModeGlobalHint:
+    "Applies this proxy to the whole dsh process, including OAuth. Requests from other plugins are affected too.",
+  proxyUrl: "Proxy URL",
+  proxyUrlPlaceholder: "Use proxy environment variables",
+  proxyUrlHint:
+    "Use an HTTP(S) proxy URL. Leave blank to use DSH_CODEX_PROXY or the standard HTTP_PROXY, HTTPS_PROXY, ALL_PROXY, and NO_PROXY environment variables.",
+  proxySave: "Save proxy",
+  proxySaved: "Proxy settings saved.",
+  proxySettingsFailed: "Proxy settings could not be saved.",
   modelCatalog: "Models shown in the selector",
   modelCatalogIntro:
     "Choose which Codex models appear in model selectors. Existing conversations can continue using a hidden model.",
@@ -151,6 +171,25 @@ export const zh: { [Key in OpenAICodexSettingsKey]: string } = {
   remoteOriginCopy: "复制命令",
   remoteOriginCopied: "已复制",
   remoteOriginCopyFailed: "无法复制命令。",
+  proxy: "网络代理",
+  proxyIntro: "选择插件应用代理的范围；修改后无需重启 dsh。",
+  proxyMode: "代理范围",
+  proxyModeOff: "跟随 dsh",
+  proxyModeScoped: "仅 Codex",
+  proxyModeGlobal: "整个 dsh",
+  proxyModeOffHint:
+    "插件不覆盖网络设置；如果 dsh 启动时已配置进程级代理，Codex 仍会遵循该策略。",
+  proxyModeScopedHint:
+    "仅认证完成后的 Codex HTTP 请求使用此代理；OAuth Token 刷新和 WebSocket 仍遵循 dsh 的网络策略。",
+  proxyModeGlobalHint:
+    "把此代理应用到整个 dsh 进程，并覆盖 OAuth；其他插件的请求也会受到影响。",
+  proxyUrl: "代理 URL",
+  proxyUrlPlaceholder: "使用代理环境变量",
+  proxyUrlHint:
+    "请输入 HTTP(S) 代理 URL；留空时读取 DSH_CODEX_PROXY，或标准的 HTTP_PROXY、HTTPS_PROXY、ALL_PROXY 与 NO_PROXY 环境变量。",
+  proxySave: "保存代理",
+  proxySaved: "代理设置已保存。",
+  proxySettingsFailed: "无法保存代理设置。",
   modelCatalog: "模型选择器中显示的模型",
   modelCatalogIntro:
     "选择要在模型选择器中显示的 Codex 模型；隐藏模型后，已有会话仍可继续使用。",

--- a/src/imagegen.ts
+++ b/src/imagegen.ts
@@ -116,8 +116,14 @@ function abortable<T>(operation: Promise<T>, signal: AbortSignal): Promise<T> {
 export class OpenAICodexImageClient {
   private readonly models: Models
 
-  /** @param credentials - shared refreshable OAuth store. */
-  constructor(credentials: OpenAICodexCredentialStore) {
+  /**
+   * @param credentials - shared refreshable OAuth store.
+   * @param requestFetch - request transport used after credentials resolve.
+   */
+  constructor(
+    credentials: OpenAICodexCredentialStore,
+    private readonly requestFetch: typeof globalThis.fetch = globalThis.fetch,
+  ) {
     const models = createModels({ credentials })
     models.setProvider(openaiCodexProvider())
     this.models = models
@@ -148,7 +154,7 @@ export class OpenAICodexImageClient {
     }
     let response: Response
     try {
-      response = await fetch(endpoint, {
+      response = await this.requestFetch(endpoint, {
         method: 'POST',
         redirect: 'error',
         headers: {
@@ -295,8 +301,9 @@ export function imagegenTool(
   ctx: Context,
   credentials: OpenAICodexCredentialStore,
   policy: ImageToolPolicy,
+  requestFetch: typeof globalThis.fetch = globalThis.fetch,
 ): ToolDefinition {
-  const client = new OpenAICodexImageClient(credentials)
+  const client = new OpenAICodexImageClient(credentials, requestFetch)
   return defineTool({
     name: IMAGEGEN_TOOL_NAME,
     description: 'Generate or edit an image with gpt-image-2. Omit both reference fields for a new image. Use referenced_image_paths for workspace files, or num_last_images_to_include for attached, viewed, or previously generated conversation images. Never provide both. Multiple images keep chronological/path-array order; identify them as Image 1, Image 2, and so on in the prompt. The generated PNG is always saved in the active local or Remote SSH workspace; output_path chooses its location, otherwise a unique generated-<timestamp>-<id>.png name is used.',

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,9 +82,17 @@ import type {
 } from "./search.ts";
 import { OpenAICodexCredentialStore, OPENAI_CODEX_PROVIDER } from "./store.ts";
 import { OpenAICodexService } from "./service.ts";
+import { DEFAULT_PROXY_PREFERENCES } from "./proxy.ts";
+import type { OpenAICodexProxyMode } from "./proxy.ts";
 
 export { OpenAICodexService } from "./service.ts";
 export type { OpenAICodexServiceOptions } from "./service.ts";
+export {
+  DEFAULT_PROXY_PREFERENCES,
+  normalizeProxyUrl,
+  OpenAICodexProxyTransport,
+} from "./proxy.ts";
+export type { OpenAICodexProxyMode, ProxyPreferences } from "./proxy.ts";
 
 export {
   assertNoOpenAICodexProviderConflict,
@@ -163,6 +171,10 @@ export interface Config {
   useWebSocketContextReuse?: boolean;
   /** Use Codex V2 Responses compaction for Harness compaction calls. */
   useNativeCompaction?: boolean;
+  /** How this plugin applies its proxy URL. */
+  proxyMode?: OpenAICodexProxyMode;
+  /** HTTP(S) proxy URL; empty uses the launch environment. */
+  proxyUrl?: string;
 }
 
 export const Config: z<Config> = z.object({
@@ -188,6 +200,10 @@ export const Config: z<Config> = z.object({
   shareImagegenWithOtherModels: z.boolean().default(true),
   useWebSocketContextReuse: z.boolean().default(false),
   useNativeCompaction: z.boolean().default(false),
+  proxyMode: z
+    .union(["off", "scoped", "global"] as const)
+    .default(DEFAULT_PROXY_PREFERENCES.proxyMode),
+  proxyUrl: z.string().default(DEFAULT_PROXY_PREFERENCES.proxyUrl),
 });
 
 /**
@@ -207,6 +223,8 @@ export function apply(ctx: Context, config: Config): void {
     shareImagegenWithOtherModels: config.shareImagegenWithOtherModels ?? true,
     useWebSocketContextReuse: config.useWebSocketContextReuse ?? false,
     useNativeCompaction: config.useNativeCompaction ?? false,
+    proxyMode: config.proxyMode ?? DEFAULT_PROXY_PREFERENCES.proxyMode,
+    proxyUrl: config.proxyUrl ?? DEFAULT_PROXY_PREFERENCES.proxyUrl,
   });
   const credentials = service.credentials;
   const imageTools = service.policy;
@@ -215,6 +233,12 @@ export function apply(ctx: Context, config: Config): void {
     ctx.llm.listProviders().map((provider) => provider.id)
   );
   ctx.provide("openAICodex", service);
+  ctx.effect(
+    () => async () => {
+      await service.dispose();
+    },
+    "dsh-openai-codex: proxy transport"
+  );
   ctx.inject(["settings"], (settingsCtx) => {
     service.attachSettings(settingsCtx);
   });
@@ -227,12 +251,14 @@ export function apply(ctx: Context, config: Config): void {
       fastMode,
       () => imageTools.modelCatalogSnapshot().models,
       () => imageTools.contextWindowSnapshot().contextWindow,
-      () => imageTools.contextWindowSnapshot().overrideSparkContextWindow
+      () => imageTools.contextWindowSnapshot().overrideSparkContextWindow,
+      service.proxy.fetch
     )
   );
   ctx.web.registerSearchProvider(
     new OpenAICodexSearchProvider({
       credentials,
+      fetch: service.proxy.fetch,
       model: config.searchModel ?? DEFAULT_OPENAI_CODEX_SEARCH_MODEL,
       mode: config.searchMode ?? DEFAULT_OPENAI_CODEX_SEARCH_MODE,
       contextSize:
@@ -255,11 +281,16 @@ export function apply(ctx: Context, config: Config): void {
       credentials,
       undefined,
       fastMode,
-      imageTools
+      imageTools,
+      service,
+      service.proxy.fetch,
+      () => service.proxy.apply()
     )
   );
   ctx.inject(["tools", "fs", "attachments"], (toolCtx) => {
-    toolCtx.tools.register(imagegenTool(toolCtx, credentials, imageTools));
+    toolCtx.tools.register(
+      imagegenTool(toolCtx, credentials, imageTools, service.proxy.fetch)
+    );
   });
   ctx.inject(["tools", "fs", "attachments", "agents"], (toolCtx) => {
     installReadImageEnhancement(toolCtx, imageTools);

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,264 @@
+/** Explicit proxy modes for OpenAI Codex HTTP traffic. */
+
+import {
+  EnvHttpProxyAgent,
+  fetch as undiciFetch,
+  getGlobalDispatcher,
+  ProxyAgent,
+  setGlobalDispatcher,
+} from "undici";
+import type { Dispatcher } from "undici";
+
+export type OpenAICodexProxyMode = "off" | "scoped" | "global";
+
+export interface ProxyPreferences {
+  /** Whether this plugin leaves networking alone, proxies Codex only, or proxies the process. */
+  proxyMode: OpenAICodexProxyMode;
+  /** Explicit HTTP(S) proxy URL; empty uses standard proxy environment variables. */
+  proxyUrl: string;
+}
+
+export const DEFAULT_PROXY_PREFERENCES: ProxyPreferences = {
+  proxyMode: "off",
+  proxyUrl: "",
+};
+
+function invalidProxyUrl(): Error {
+  return new Error("Proxy URL must use http:// or https://");
+}
+
+/** Validate a persisted proxy value without echoing possible credentials. */
+export function normalizeProxyUrl(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return "";
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    throw invalidProxyUrl();
+  }
+  if (
+    (parsed.protocol !== "http:" && parsed.protocol !== "https:") ||
+    parsed.hostname.length === 0
+  ) {
+    throw invalidProxyUrl();
+  }
+  return trimmed;
+}
+
+function configuredProxyUrl(proxyUrl: string): string {
+  const explicit = normalizeProxyUrl(proxyUrl);
+  if (explicit.length > 0) return explicit;
+  const pluginEnvironment = process.env.DSH_CODEX_PROXY?.trim() ?? "";
+  return pluginEnvironment.length > 0
+    ? normalizeProxyUrl(pluginEnvironment)
+    : "";
+}
+
+function environmentProxyKey(): string {
+  return [
+    process.env.DSH_CODEX_PROXY,
+    process.env.https_proxy,
+    process.env.HTTPS_PROXY,
+    process.env.http_proxy,
+    process.env.HTTP_PROXY,
+    process.env.all_proxy,
+    process.env.ALL_PROXY,
+    process.env.no_proxy,
+    process.env.NO_PROXY,
+  ]
+    .map((value) => value?.trim() ?? "")
+    .join("\u0000");
+}
+
+function proxyKey(proxyUrl: string): string {
+  const explicit = configuredProxyUrl(proxyUrl);
+  return explicit.length === 0
+    ? `env:${environmentProxyKey()}`
+    : `url:${explicit}`;
+}
+
+function createScopedDispatcher(proxyUrl: string): Dispatcher {
+  const explicit = configuredProxyUrl(proxyUrl);
+  return explicit.length > 0
+    ? new ProxyAgent(explicit)
+    : new EnvHttpProxyAgent();
+}
+
+function createFallbackGlobalDispatcher(proxyUrl: string): Dispatcher {
+  const explicit = configuredProxyUrl(proxyUrl);
+  const inheritedNoProxy =
+    process.env.no_proxy?.trim() || process.env.NO_PROXY?.trim();
+  const noProxy = [
+    inheritedNoProxy,
+    "localhost",
+    "127.0.0.1",
+    "::1",
+    "0.0.0.0",
+  ]
+    .filter((value): value is string => value !== undefined && value.length > 0)
+    .join(",");
+  return new EnvHttpProxyAgent({
+    ...(explicit.length === 0
+      ? {}
+      : { httpProxy: explicit, httpsProxy: explicit }),
+    noProxy,
+  });
+}
+
+function globalProxyEnvironment(proxyUrl: string): {
+  get(name: string): { value: string } | undefined;
+} {
+  const explicit = configuredProxyUrl(proxyUrl);
+  return {
+    get(name) {
+      const lower = name.toLowerCase();
+      if (
+        explicit.length > 0 &&
+        (lower === "http_proxy" || lower === "https_proxy")
+      ) {
+        return { value: explicit };
+      }
+      const value = process.env[name];
+      return value === undefined ? undefined : { value };
+    },
+  };
+}
+
+type ProxyEnvironment = ReturnType<typeof globalProxyEnvironment>;
+type ProxyDisposer = () => Promise<void>;
+
+interface HarnessProxyModule {
+  installProxyFromEnvironment?: (
+    environment: ProxyEnvironment,
+    report: (message: string) => void
+  ) => Promise<ProxyDisposer>;
+}
+
+const HARNESS_PROXY_MODULE = "@deepseek-ai/dsh-http-proxy";
+
+function moduleIsUnavailable(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    error.code === "ERR_MODULE_NOT_FOUND" &&
+    error.message.includes(HARNESS_PROXY_MODULE)
+  );
+}
+
+async function installFallbackGlobalProxy(
+  proxyUrl: string
+): Promise<ProxyDisposer> {
+  const previous = getGlobalDispatcher();
+  const dispatcher = createFallbackGlobalDispatcher(proxyUrl);
+  setGlobalDispatcher(dispatcher);
+  return async () => {
+    if (getGlobalDispatcher() === dispatcher) {
+      setGlobalDispatcher(previous);
+    }
+    await dispatcher.close();
+  };
+}
+
+async function installHarnessGlobalProxy(
+  proxyUrl: string
+): Promise<ProxyDisposer> {
+  let loaded: HarnessProxyModule;
+  try {
+    // DSH 0.1.3 owns this process-wide policy. Keep the import optional while
+    // the plugin still supports the published 0.1.1 line that predates it.
+    loaded = (await import(HARNESS_PROXY_MODULE)) as HarnessProxyModule;
+  } catch (error) {
+    if (!moduleIsUnavailable(error)) throw error;
+    return await installFallbackGlobalProxy(proxyUrl);
+  }
+  if (loaded.installProxyFromEnvironment === undefined) {
+    return await installFallbackGlobalProxy(proxyUrl);
+  }
+  return await loaded.installProxyFromEnvironment(
+    globalProxyEnvironment(proxyUrl),
+    (message) => {
+      process.stderr.write(`[dsh-codex] ${message}\n`);
+    }
+  );
+}
+
+/**
+ * Owns request-scoped dispatch and an optional nested Harness-wide policy.
+ * Disposing the nested policy restores the launcher's original proxy policy.
+ */
+export class OpenAICodexProxyTransport {
+  private readonly dispatchers = new Map<string, Dispatcher>();
+  private globalDispose: (() => Promise<void>) | undefined;
+  private appliedGlobalKey: string | undefined;
+  private transition: Promise<void> = Promise.resolve();
+  private disposed = false;
+
+  constructor(private readonly preferences: () => ProxyPreferences) {}
+
+  /** Reconcile process-global state after a live setting change. */
+  apply(): Promise<void> {
+    const preferences = this.preferences();
+    normalizeProxyUrl(preferences.proxyUrl);
+    const desiredKey =
+      preferences.proxyMode === "global"
+        ? proxyKey(preferences.proxyUrl)
+        : undefined;
+    this.transition = this.transition.catch(() => undefined).then(async () => {
+      if (this.disposed || desiredKey === this.appliedGlobalKey) return;
+      await this.restoreGlobal();
+      if (desiredKey === undefined) return;
+      this.globalDispose = await installHarnessGlobalProxy(
+        preferences.proxyUrl
+      );
+      this.appliedGlobalKey = desiredKey;
+    });
+    return this.transition;
+  }
+
+  /** Fetch implementation injected into Codex-owned HTTP call sites. */
+  readonly fetch: typeof globalThis.fetch = async (input, init) => {
+    await this.apply();
+    const preferences = this.preferences();
+    if (preferences.proxyMode !== "scoped") {
+      return await globalThis.fetch(input, init);
+    }
+    const options = {
+      ...(init ?? {}),
+      dispatcher: this.dispatcher(preferences.proxyUrl),
+    } as Parameters<typeof undiciFetch>[1];
+    return (await undiciFetch(
+      input as Parameters<typeof undiciFetch>[0],
+      options
+    )) as unknown as Response;
+  };
+
+  /** Restore host networking and close all provider-owned pools. */
+  async dispose(): Promise<void> {
+    await this.transition.catch(() => undefined);
+    this.disposed = true;
+    await this.restoreGlobal();
+    const dispatchers = [...this.dispatchers.values()];
+    this.dispatchers.clear();
+    await Promise.allSettled(
+      dispatchers.map(async (dispatcher) => await dispatcher.close())
+    );
+  }
+
+  private dispatcher(proxyUrl: string): Dispatcher {
+    const key = proxyKey(proxyUrl);
+    let dispatcher = this.dispatchers.get(key);
+    if (dispatcher === undefined) {
+      dispatcher = createScopedDispatcher(proxyUrl);
+      this.dispatchers.set(key, dispatcher);
+    }
+    return dispatcher;
+  }
+
+  private async restoreGlobal(): Promise<void> {
+    const dispose = this.globalDispose;
+    this.globalDispose = undefined;
+    this.appliedGlobalKey = undefined;
+    await dispose?.();
+  }
+}

--- a/src/responses.ts
+++ b/src/responses.ts
@@ -8,6 +8,7 @@ import type {
   AssistantMessageEventStream,
   Api,
   Context as PiContext,
+  FetchFunction,
   Model,
   Provider,
   SimpleStreamOptions,
@@ -325,7 +326,10 @@ function retainedCompactionInput(input: readonly unknown[]): unknown[] {
 export class OpenAICodexResponseRuntime {
   private readonly compactionCalls = new Map<string, number>()
 
-  constructor(private readonly preferences: () => ResponseApiPreferences) {}
+  constructor(
+    private readonly preferences: () => ResponseApiPreferences,
+    private readonly requestFetch: FetchFunction = globalThis.fetch
+  ) {}
 
   /** Mark one Harness stream call as compaction until its iterator closes. */
   enterCompaction(sessionId: string | undefined): () => void {
@@ -475,7 +479,7 @@ export class OpenAICodexResponseRuntime {
       let response: Response
       try {
         const signal = requestSignal(options?.signal, options?.timeoutMs)
-        response = await fetch(OPENAI_CODEX_RESPONSES_URL, {
+        response = await (options?.fetch ?? this.requestFetch)(OPENAI_CODEX_RESPONSES_URL, {
           method: 'POST',
           headers,
           body: JSON.stringify(body),

--- a/src/search.ts
+++ b/src/search.ts
@@ -74,6 +74,8 @@ export interface OpenAICodexSearchRequestRecord {
 export interface OpenAICodexSearchProviderOptions {
   /** Shared persistent OAuth store. */
   readonly credentials: OpenAICodexCredentialStore
+  /** Request transport used after credentials have been resolved. */
+  readonly fetch?: typeof globalThis.fetch
   /** Model sent to the standalone search endpoint. */
   readonly model: string
   /** Cached, indexed, or live external-web policy. */
@@ -282,7 +284,7 @@ export class OpenAICodexSearchProvider implements WebSearchProvider {
 
     let response: Response
     try {
-      response = await fetch(OPENAI_CODEX_SEARCH_URL, {
+      response = await (this.options.fetch ?? globalThis.fetch)(OPENAI_CODEX_SEARCH_URL, {
         method: 'POST',
         redirect: 'error',
         headers: {

--- a/src/service.ts
+++ b/src/service.ts
@@ -9,6 +9,8 @@ import {
 } from "./auth.ts";
 import type { OpenAICodexAuthStatus } from "./auth.ts";
 import { OpenAICodexCredentialStore } from "./store.ts";
+import { OpenAICodexProxyTransport } from "./proxy.ts";
+import type { ProxyPreferences } from "./proxy.ts";
 import { ImageToolPolicy } from "./tool-policy.ts";
 import type {
   ContextWindowPreferences,
@@ -32,7 +34,8 @@ export interface OpenAICodexServiceOptions
   extends
     ImageToolPreferences,
     ResponseApiPreferences,
-    ContextWindowPreferences {
+    ContextWindowPreferences,
+    ProxyPreferences {
   models?: string[];
   modelCatalog: readonly ModelCatalogEntry[];
 }
@@ -44,9 +47,26 @@ export interface OpenAICodexServiceOptions
 export class OpenAICodexService {
   readonly credentials = new OpenAICodexCredentialStore();
   readonly policy: ImageToolPolicy;
+  readonly proxy: OpenAICodexProxyTransport;
+  private readonly stopProxyWatch: () => void;
 
   constructor(options: OpenAICodexServiceOptions) {
     this.policy = new ImageToolPolicy(options, options.modelCatalog);
+    this.proxy = new OpenAICodexProxyTransport(() =>
+      this.policy.proxySnapshot()
+    );
+    void this.proxy.apply().catch((error: unknown) => {
+      process.stderr.write(
+        `[dsh-codex] failed to apply proxy settings: ${error instanceof Error ? error.message : String(error)}\n`
+      );
+    });
+    this.stopProxyWatch = this.policy.watchProxyPreferences(() => {
+      void this.proxy.apply().catch((error: unknown) => {
+        process.stderr.write(
+          `[dsh-codex] failed to apply proxy settings: ${error instanceof Error ? error.message : String(error)}\n`
+        );
+      });
+    });
   }
 
   /** Attach the durable settings document when the active profile provides it. */
@@ -55,8 +75,9 @@ export class OpenAICodexService {
   }
 
   /** Start the provider-native OAuth lifecycle. */
-  login(interaction: AuthInteraction): Promise<void> {
-    return loginOpenAICodex(interaction, this.credentials);
+  async login(interaction: AuthInteraction): Promise<void> {
+    await this.proxy.apply();
+    return await loginOpenAICodex(interaction, this.credentials);
   }
 
   /** Remove this plugin's credential without touching Codex CLI/Desktop. */
@@ -71,7 +92,7 @@ export class OpenAICodexService {
 
   /** Read current subscription limits without issuing a model request. */
   usage(): Promise<OpenAICodexUsage> {
-    return readOpenAICodexRateLimits(this.credentials);
+    return readOpenAICodexRateLimits(this.credentials, this.proxy.fetch);
   }
 
   imagePreferences(): ImageToolPreferences {
@@ -106,5 +127,22 @@ export class OpenAICodexService {
 
   modelCatalogSettings(): ModelCatalogSettings {
     return this.policy.modelCatalogSnapshot();
+  }
+
+  proxyPreferences(): ProxyPreferences {
+    return this.policy.proxySnapshot();
+  }
+
+  async updateProxyPreferences(
+    patch: Partial<ProxyPreferences>
+  ): Promise<ProxyPreferences> {
+    const preferences = await this.policy.updateProxy(patch);
+    await this.proxy.apply();
+    return preferences;
+  }
+
+  async dispose(): Promise<void> {
+    this.stopProxyWatch();
+    await this.proxy.dispose();
   }
 }

--- a/src/tool-policy.ts
+++ b/src/tool-policy.ts
@@ -5,6 +5,11 @@ import type {
 } from "@deepseek-ai/dsh-settings";
 import type { ToolExecution } from "@deepseek-ai/dsh-tools";
 import z from "@deepseek-ai/schemastery";
+import {
+  DEFAULT_PROXY_PREFERENCES,
+  normalizeProxyUrl,
+} from "./proxy.ts";
+import type { ProxyPreferences } from "./proxy.ts";
 import { OPENAI_CODEX_PROVIDER } from "./store.ts";
 
 /** User-controlled image-tool integration. */
@@ -49,7 +54,8 @@ interface OpenAICodexPreferences
     ImageToolPreferences,
     ResponseApiPreferences,
     ModelCatalogPreferences,
-    ContextWindowPreferences {
+    ContextWindowPreferences,
+    ProxyPreferences {
   /** Migration-only key written by the unreleased store:true experiment. */
   useStatefulResponses: boolean;
 }
@@ -90,6 +96,8 @@ function preferenceSchema(
       ])
       .default(null),
     overrideSparkContextWindow: z.boolean().default(false),
+    proxyMode: z.union(["off", "scoped", "global"] as const).default("off"),
+    proxyUrl: z.string().default(""),
     models: z.array(z.string()).default([...defaultModels]),
   });
 }
@@ -99,6 +107,7 @@ export class ImageToolPolicy {
   private current: OpenAICodexPreferences;
   private scope: SettingsScope<OpenAICodexPreferences> | undefined;
   private readonly imageWatchers = new Set<() => void>();
+  private readonly proxyWatchers = new Set<() => void>();
   private readonly modelCatalog: readonly ModelCatalogEntry[];
 
   constructor(
@@ -110,6 +119,7 @@ export class ImageToolPolicy {
       ...DEFAULT_IMAGE_TOOL_PREFERENCES,
       ...DEFAULT_RESPONSE_API_PREFERENCES,
       ...DEFAULT_CONTEXT_WINDOW_PREFERENCES,
+      ...DEFAULT_PROXY_PREFERENCES,
       useStatefulResponses: false,
       ...base,
       models: this.normalizeModels(
@@ -215,6 +225,37 @@ export class ImageToolPolicy {
     return this.contextWindowSnapshot();
   }
 
+  /** Return the live provider proxy mode and explicit URL. */
+  proxySnapshot(): ProxyPreferences {
+    return {
+      proxyMode: this.current.proxyMode,
+      proxyUrl: this.current.proxyUrl,
+    };
+  }
+
+  /** Observe proxy changes so the transport can reconcile global mode. */
+  watchProxyPreferences(listener: () => void): () => void {
+    this.proxyWatchers.add(listener);
+    return () => {
+      this.proxyWatchers.delete(listener);
+    };
+  }
+
+  /** Persist a validated proxy mode or URL. */
+  async updateProxy(
+    patch: Partial<ProxyPreferences>
+  ): Promise<ProxyPreferences> {
+    if (this.scope === undefined)
+      throw new Error("OpenAI Codex settings service is unavailable");
+    const normalized =
+      patch.proxyUrl === undefined
+        ? patch
+        : { ...patch, proxyUrl: normalizeProxyUrl(patch.proxyUrl) };
+    await this.scope.update(normalized);
+    this.replace(this.scope.get());
+    return this.proxySnapshot();
+  }
+
   /** Return available models and the live discovery subset for the browser. */
   modelCatalogSnapshot(): ModelCatalogSettings {
     return {
@@ -257,9 +298,15 @@ export class ImageToolPolicy {
       next.modifyReadImage !== this.current.modifyReadImage ||
       next.shareImagegenWithOtherModels !==
         this.current.shareImagegenWithOtherModels;
+    const proxyChanged =
+      next.proxyMode !== this.current.proxyMode ||
+      next.proxyUrl !== this.current.proxyUrl;
     this.current = next;
     if (imageChanged) {
       for (const listener of this.imageWatchers) listener();
+    }
+    if (proxyChanged) {
+      for (const listener of this.proxyWatchers) listener();
     }
   }
 

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -344,11 +344,22 @@ function formatTokenCount(tokens: number): string {
     : `${tokens} tokens`;
 }
 
+function formatProxyUrl(proxyUrl: string): string {
+  if (proxyUrl.length === 0) return "environment";
+  try {
+    const parsed = new URL(proxyUrl);
+    return `${parsed.protocol}//${parsed.host}`;
+  } catch {
+    return "invalid";
+  }
+}
+
 function formatConfig(service: OpenAICodexService): string {
   const image = service.imagePreferences();
   const responses = service.responsePreferences();
   const contextWindow = service.contextWindowPreferences();
   const catalog = service.modelCatalogSettings();
+  const proxy = service.proxyPreferences();
   const enabledModels = new Set(catalog.models);
   const models = catalog.availableModels.flatMap((model) => [
     "",
@@ -364,6 +375,8 @@ function formatConfig(service: OpenAICodexService): string {
     `native-compaction: ${responses.useNativeCompaction ? "on" : "off"}`,
     `context-window: ${contextWindow.contextWindow === null ? "provider-default" : `${contextWindow.contextWindow} tokens`}`,
     `spark-context-window: ${contextWindow.overrideSparkContextWindow ? "on" : "off"}`,
+    `proxy-mode: ${proxy.proxyMode}`,
+    `proxy-url: ${formatProxyUrl(proxy.proxyUrl)}`,
     ...models,
   ].join("\n");
 }

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -224,6 +224,7 @@ export function parseOpenAICodexUsage(value: unknown): OpenAICodexUsage {
  */
 export async function readOpenAICodexRateLimits(
   store: OpenAICodexCredentialStore,
+  requestFetch: typeof globalThis.fetch = globalThis.fetch,
 ): Promise<OpenAICodexUsage> {
   const models = createModels({ credentials: store })
   models.setProvider(openaiCodexProvider())
@@ -234,7 +235,7 @@ export async function readOpenAICodexRateLimits(
   if (access === undefined || access.length === 0 || typeof accountId !== 'string' || accountId.length === 0) {
     throw new Error('OpenAI Codex is signed out')
   }
-  const response = await fetch(OPENAI_CODEX_USAGE_URL, {
+  const response = await requestFetch(OPENAI_CODEX_USAGE_URL, {
     method: 'GET',
     redirect: 'error',
     headers: {

--- a/tests/adapter.spec.ts
+++ b/tests/adapter.spec.ts
@@ -265,9 +265,22 @@ describe("OpenAI Codex adapter policy", () => {
   });
 
   it("projects provider context capacities into the settings catalog", () => {
-    expect(
-      openAICodexModelCatalog().find((model) => model.id === "gpt-5.6-sol")
-    ).toMatchObject({
+    const catalog = openAICodexModelCatalog();
+    expect(catalog.map((model) => model.id)).toEqual([
+      "gpt-6-astra",
+      "gpt-5.6-luna",
+      "gpt-5.6-sol",
+      "gpt-5.6-terra",
+      "gpt-5.3-codex-spark",
+      "gpt-5.5",
+      "gpt-5.4",
+      "gpt-5.4-mini",
+    ]);
+    expect(catalog.find((model) => model.id === "gpt-6-astra")).toMatchObject({
+      name: "GPT-6 Astra",
+      contextWindow: 1_050_000,
+    });
+    expect(catalog.find((model) => model.id === "gpt-5.6-sol")).toMatchObject({
       contextWindow: 272_000,
     });
   });
@@ -282,6 +295,7 @@ describe("OpenAI Codex adapter policy", () => {
     const models = await adapter.listModels(OPENAI_CODEX_PROVIDER);
     expect(models.map((model) => model.id)).toEqual(
       expect.arrayContaining([
+        "gpt-6-astra",
         "gpt-5.4",
         "gpt-5.6-luna",
         "gpt-5.6-sol",

--- a/tests/adapter.spec.ts
+++ b/tests/adapter.spec.ts
@@ -23,6 +23,8 @@ describe("OpenAI Codex adapter policy", () => {
     expect(Config({}).models).toBeUndefined();
     expect(Config({}).contextWindow).toBeUndefined();
     expect(Config({}).overrideSparkContextWindow).toBe(false);
+    expect(Config({}).proxyMode).toBe("off");
+    expect(Config({}).proxyUrl).toBe("");
     expect(
       Config({
         models: [],
@@ -35,6 +37,7 @@ describe("OpenAI Codex adapter policy", () => {
       overrideSparkContextWindow: true,
     });
     expect(() => Config({ contextWindow: 0 })).toThrow();
+    expect(() => Config({ proxyMode: "sometimes" as never })).toThrow();
   });
 
   it("supplies the complete request-image policy required by current DSH runtimes", () => {

--- a/tests/auth-routes.spec.ts
+++ b/tests/auth-routes.spec.ts
@@ -12,6 +12,7 @@ import {
   OPENAI_CODEX_AUTH_STATUS_PATH,
   OPENAI_CODEX_CONTEXT_WINDOW_SETTINGS_PATH,
   OPENAI_CODEX_MODEL_CATALOG_SETTINGS_PATH,
+  OPENAI_CODEX_PROXY_SETTINGS_PATH,
   REMOTE_WEB_ORIGIN_NOT_TRUSTED,
   registerOpenAICodexAuthRoutes,
   trustedRequestDecision,
@@ -75,6 +76,10 @@ interface CapturedRoute {
 function captureRoutes(
   trustedOrigins: OpenAICodexTrustedOriginsStore = emptyTrustedOrigins,
   preferences?: ImageToolPolicy,
+  proxySettings?: {
+    proxyPreferences(): { proxyMode: 'off' | 'scoped' | 'global'; proxyUrl: string }
+    updateProxyPreferences(patch: Partial<{ proxyMode: 'off' | 'scoped' | 'global'; proxyUrl: string }>): Promise<{ proxyMode: 'off' | 'scoped' | 'global'; proxyUrl: string }>
+  },
 ): CapturedRoute[] {
   const routes: CapturedRoute[] = []
   const ctx = {
@@ -88,7 +93,7 @@ function captureRoutes(
       return factory()
     },
   } as unknown as Context
-  registerOpenAICodexAuthRoutes(ctx, store, trustedOrigins, undefined, preferences)
+  registerOpenAICodexAuthRoutes(ctx, store, trustedOrigins, undefined, preferences, proxySettings)
   return routes
 }
 
@@ -140,6 +145,36 @@ afterEach(async () => {
 })
 
 describe('OpenAI Codex Web OAuth boundary', () => {
+  it('serves and validates the three-state proxy settings', async () => {
+    let current = { proxyMode: 'off' as 'off' | 'scoped' | 'global', proxyUrl: '' }
+    const proxySettings = {
+      proxyPreferences: vi.fn(() => ({ ...current })),
+      updateProxyPreferences: vi.fn(async (patch: Partial<typeof current>) => {
+        current = { ...current, ...patch }
+        return { ...current }
+      }),
+    }
+    const route = captureRoutes(emptyTrustedOrigins, undefined, proxySettings)
+      .find(candidate => candidate.path === OPENAI_CODEX_PROXY_SETTINGS_PATH)
+    if (route === undefined) throw new Error('proxy settings route was not registered')
+
+    const getResponse = response()
+    await route.handler(request({}), getResponse)
+    expect(JSON.parse(getResponse.observed.body ?? 'null')).toEqual({ proxyMode: 'off', proxyUrl: '' })
+
+    const postResponse = response()
+    await route.handler(request({
+      method: 'POST',
+      body: JSON.stringify({ proxyMode: 'scoped', proxyUrl: 'http://127.0.0.1:7890' }),
+    }), postResponse)
+    expect(postResponse.observed.status).toBe(200)
+    expect(current).toEqual({ proxyMode: 'scoped', proxyUrl: 'http://127.0.0.1:7890' })
+
+    const invalidResponse = response()
+    await route.handler(request({ method: 'POST', body: JSON.stringify({ proxyMode: 'sometimes' }) }), invalidResponse)
+    expect(invalidResponse.observed.status).toBe(400)
+  })
+
   it('serves and updates the model discovery subset through the plugin settings route', async () => {
     const snapshot = {
       availableModels: [

--- a/tests/imagegen.spec.ts
+++ b/tests/imagegen.spec.ts
@@ -114,6 +114,18 @@ function successfulFetch() {
 }
 
 describe('imagegen', () => {
+  it('uses an injected request transport for image generation', async () => {
+    const requestFetch = successfulFetch()
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('global fetch must not run') }))
+    const client = new OpenAICodex.OpenAICodexImageClient(
+      new OpenAICodex.OpenAICodexCredentialStore(),
+      requestFetch,
+    )
+
+    await expect(client.generate('A tiny red pixel', [], signal)).resolves.toEqual(PNG_1X1)
+    expect(requestFetch).toHaveBeenCalledOnce()
+  })
+
   it('generates an attachment and optionally publishes the same PNG to the workspace', async () => {
     const ctx = await setup()
     const fetchMock = successfulFetch()

--- a/tests/openai-codex-settings.client.spec.tsx
+++ b/tests/openai-codex-settings.client.spec.tsx
@@ -49,6 +49,7 @@ describe("OpenAI Codex settings model catalog", () => {
     let selected = availableModels.slice(1).map((model) => model.id);
     let contextWindow: number | null = null;
     let overrideSparkContextWindow = false;
+    let proxy = { proxyMode: "off", proxyUrl: "" };
     const fetchMock = vi.fn(
       async (
         input: string | URL | Request,
@@ -67,6 +68,15 @@ describe("OpenAI Codex settings model catalog", () => {
             useWebSocketContextReuse: false,
             useNativeCompaction: false,
           });
+        if (path.endsWith("/proxy")) {
+          if (init?.method === "POST") {
+            proxy = {
+              ...proxy,
+              ...(JSON.parse(String(init.body)) as Partial<typeof proxy>),
+            };
+          }
+          return json(proxy);
+        }
         if (path.endsWith("/context-window")) {
           if (init?.method === "POST") {
             const patch = JSON.parse(String(init.body)) as Partial<{
@@ -160,6 +170,36 @@ describe("OpenAI Codex settings model catalog", () => {
       contextWindow: null,
     });
     expect(screen.getByText(en.contextWindowHint)).toBeDefined();
+
+    const scopedProxy = await screen.findByRole<HTMLButtonElement>("radio", {
+      name: en.proxyModeScoped,
+    });
+    expect(scopedProxy.getAttribute("aria-checked")).toBe("false");
+    fireEvent.click(scopedProxy);
+    await waitFor(() => {
+      expect(proxy.proxyMode).toBe("scoped");
+      expect(scopedProxy.getAttribute("aria-checked")).toBe("true");
+    });
+    const proxyUrl = screen.getByRole<HTMLInputElement>("textbox", {
+      name: en.proxyUrl,
+    });
+    fireEvent.change(proxyUrl, {
+      target: { value: "http://127.0.0.1:7890" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: en.proxySave }));
+    await waitFor(() => {
+      expect(proxy.proxyUrl).toBe("http://127.0.0.1:7890");
+    });
+    const proxyPosts = fetchMock.mock.calls.filter(
+      ([input, init]) =>
+        String(input).endsWith("/proxy") && init?.method === "POST"
+    );
+    expect(JSON.parse(String(proxyPosts[0]?.[1]?.body))).toEqual({
+      proxyMode: "scoped",
+    });
+    expect(JSON.parse(String(proxyPosts[1]?.[1]?.body))).toEqual({
+      proxyUrl: "http://127.0.0.1:7890",
+    });
 
     fireEvent.change(capacity, { target: { value: "1.0001" } });
     fireEvent.click(screen.getByRole("button", { name: en.contextWindowSave }));

--- a/tests/proxy.spec.ts
+++ b/tests/proxy.spec.ts
@@ -1,0 +1,93 @@
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+import { getGlobalDispatcher } from "undici";
+import {
+  normalizeProxyUrl,
+  OpenAICodexProxyTransport,
+} from "../src/proxy.ts";
+import type { ProxyPreferences } from "../src/proxy.ts";
+
+const transports = new Set<OpenAICodexProxyTransport>();
+
+afterEach(async () => {
+  await Promise.all([...transports].map(async (transport) => transport.dispose()));
+  transports.clear();
+});
+
+function transportFor(preferences: ProxyPreferences): OpenAICodexProxyTransport {
+  const transport = new OpenAICodexProxyTransport(() => preferences);
+  transports.add(transport);
+  return transport;
+}
+
+describe("OpenAICodexProxyTransport", () => {
+  it("accepts only HTTP(S) proxy URLs without reflecting credentials", () => {
+    expect(normalizeProxyUrl("  http://127.0.0.1:7890  ")).toBe(
+      "http://127.0.0.1:7890"
+    );
+    expect(() => normalizeProxyUrl("socks5://secret@example.test:1080")).toThrow(
+      "http:// or https://"
+    );
+    expect(() => normalizeProxyUrl("socks5://secret@example.test:1080")).not.toThrow(
+      /secret/u
+    );
+  });
+
+  it("leaves the process dispatcher untouched when disabled", async () => {
+    const original = getGlobalDispatcher();
+    const transport = transportFor({ proxyMode: "off", proxyUrl: "" });
+
+    await transport.apply();
+
+    expect(getGlobalDispatcher()).toBe(original);
+  });
+
+  it("restores the previous process dispatcher after global mode", async () => {
+    const original = getGlobalDispatcher();
+    const preferences: ProxyPreferences = {
+      proxyMode: "global",
+      proxyUrl: "http://127.0.0.1:7890",
+    };
+    const transport = transportFor(preferences);
+
+    await transport.apply();
+    expect(getGlobalDispatcher()).not.toBe(original);
+
+    preferences.proxyMode = "off";
+    await transport.apply();
+    expect(getGlobalDispatcher()).toBe(original);
+  });
+
+  it("routes a scoped Codex request through the configured proxy", async () => {
+    let observedUrl: string | undefined;
+    const server = createServer((request, response) => {
+      observedUrl = request.url;
+      response.writeHead(200, { "content-type": "text/plain" });
+      response.end("proxied");
+    });
+    const address = await new Promise<AddressInfo>((resolve) => {
+      server.listen(0, "127.0.0.1", () => {
+        resolve(server.address() as AddressInfo);
+      });
+    });
+    try {
+      const transport = transportFor({
+        proxyMode: "scoped",
+        proxyUrl: `http://127.0.0.1:${String(address.port)}`,
+      });
+
+      const response = await transport.fetch("http://codex-probe.invalid/test");
+
+      expect(await response.text()).toBe("proxied");
+      expect(observedUrl).toBe("http://codex-probe.invalid/test");
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error === undefined) resolve();
+          else reject(error);
+        });
+      });
+    }
+  });
+});

--- a/tests/search.spec.ts
+++ b/tests/search.spec.ts
@@ -104,6 +104,17 @@ describe('OpenAI Codex search response mapping', () => {
 })
 
 describe('OpenAI Codex standalone search request', () => {
+  it('uses an injected request transport without replacing global fetch', async () => {
+    const requestFetch = vi.fn(async () => jsonResponse(searchPayload))
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('global fetch must not run') }))
+    const search = await provider({ fetch: requestFetch })
+
+    await expect(search.search({ query: 'scoped request' })).resolves.toMatchObject({
+      content: 'A synthesized answer.',
+    })
+    expect(requestFetch).toHaveBeenCalledOnce()
+  })
+
   it.each([
     ['cached', false],
     ['indexed', 'indexed'],

--- a/tests/tool-policy.spec.ts
+++ b/tests/tool-policy.spec.ts
@@ -53,12 +53,20 @@ describe("ImageToolPolicy", () => {
       contextWindow: null,
       overrideSparkContextWindow: false,
     });
+    expect(policy.proxySnapshot()).toEqual({
+      proxyMode: "off",
+      proxyUrl: "",
+    });
 
     await policy.update({ shareImagegenWithOtherModels: false });
     await policy.updateResponseApi({ useNativeCompaction: true });
     await policy.updateContextWindow({
       contextWindow: 512_000,
       overrideSparkContextWindow: true,
+    });
+    await policy.updateProxy({
+      proxyMode: "scoped",
+      proxyUrl: "http://127.0.0.1:7890",
     });
 
     expect(policy.snapshot()).toEqual({
@@ -72,6 +80,10 @@ describe("ImageToolPolicy", () => {
     expect(policy.contextWindowSnapshot()).toEqual({
       contextWindow: 512_000,
       overrideSparkContextWindow: true,
+    });
+    expect(policy.proxySnapshot()).toEqual({
+      proxyMode: "scoped",
+      proxyUrl: "http://127.0.0.1:7890",
     });
   });
 
@@ -177,5 +189,22 @@ describe("ImageToolPolicy", () => {
       contextWindow: null,
       overrideSparkContextWindow: false,
     });
+    expect(policy.proxySnapshot()).toEqual({
+      proxyMode: "off",
+      proxyUrl: "",
+    });
+  });
+
+  it("validates proxy URLs before persisting them", async () => {
+    const ctx = new Context();
+    context = ctx;
+    await ctx.plugin(MemorySettings);
+    const policy = new ImageToolPolicy();
+    policy.attach(ctx);
+
+    await expect(
+      policy.updateProxy({ proxyUrl: "socks5://127.0.0.1:1080" })
+    ).rejects.toThrow("http:// or https://");
+    expect(policy.proxySnapshot()).toEqual({ proxyMode: "off", proxyUrl: "" });
   });
 });

--- a/tests/tui.spec.ts
+++ b/tests/tui.spec.ts
@@ -25,6 +25,10 @@ function fakeService(): OpenAICodexService {
     contextWindow: null,
     overrideSparkContextWindow: false,
   };
+  let proxyPreferences = {
+    proxyMode: "off" as const,
+    proxyUrl: "",
+  };
   return {
     authStatus: vi.fn(async () => ({
       authenticated: true,
@@ -63,6 +67,11 @@ function fakeService(): OpenAICodexService {
         { id: "gpt-5.6-luna", name: "GPT-5.6 Luna", contextWindow: 272_000 },
       ],
     })),
+    proxyPreferences: vi.fn(() => ({ ...proxyPreferences })),
+    updateProxyPreferences: vi.fn(async (patch) => {
+      proxyPreferences = { ...proxyPreferences, ...patch };
+      return { ...proxyPreferences };
+    }),
     updateResponsePreferences: vi.fn(async (patch) => {
       responsePreferences = { ...responsePreferences, ...patch };
       return { ...responsePreferences };

--- a/tests/usage.spec.ts
+++ b/tests/usage.spec.ts
@@ -179,6 +179,19 @@ describe('OpenAI Codex usage', () => {
     })
   })
 
+  it('uses an injected request transport for the usage endpoint', async () => {
+    const requestFetch = vi.fn(async () => response(payload()))
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('global fetch must not run') }))
+
+    const usage = await readOpenAICodexRateLimits(
+      await authenticatedStore(),
+      requestFetch,
+    )
+
+    expect(usage.rateLimits[0]?.windows[0]?.remainingPercent).toBe(87)
+    expect(requestFetch).toHaveBeenCalledOnce()
+  })
+
   it.each([401, 403])('throws a secret-free reauthorization error for usage HTTP %s', async status => {
     vi.stubGlobal('fetch', vi.fn(async () => response({
       error: 'fixture-response-secret',


### PR DESCRIPTION
## Problem

Node.js `fetch` does not automatically honor `HTTP_PROXY` / `HTTPS_PROXY`, so Codex authentication and API requests may connect directly and fail with `403 unsupported_country_region_territory`. The upstream pi-ai Codex catalog also does not yet advertise GPT-6 Astra.

## Changes

- Add a three-state proxy scope control:
  - **Follow dsh** — leave the process network policy unchanged (default)
  - **Codex only** — inject the proxy only into Codex HTTP requests after authentication
  - **All dsh** — install the selected proxy through dsh's process-wide proxy policy, including OAuth/token traffic
- Resolve an empty proxy URL from `DSH_CODEX_PROXY`, then standard `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, and `NO_PROXY` variables
- Validate HTTP(S) proxy URLs and apply settings live
- Present proxy modes as an accessible segmented control with arrow-key navigation
- Add GPT-6 Astra through a provider catalog addition until pi-ai publishes it
- Order the model picker as Astra, GPT-5.6, Spark, GPT-5.5, then GPT-5.4 while retaining unknown future upstream models
- Update English and Chinese documentation and settings copy

## Scope notes

`Codex only` intentionally does not alter OAuth token refresh or WebSocket transport because those paths do not currently expose a request-local fetch injection point. Use `All dsh` when those requests must also use the proxy.

## Verification

- `pnpm check`
- 23 test files passed
- 170 tests passed
- TypeScript typecheck and production build passed
- Web settings model order verified manually

Closes #17
Closes #19