### PR TITLE
fix: unstick signing-in status and harden retry policy

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -55,6 +55,18 @@ function migrateReplayHistory(options: GenerateOptions): GenerateOptions {
 }
 
 /**
+ * Codex traffic rides on chatgpt.com, which is frequently reached through a
+ * local proxy tunnel that blips for tens of seconds at a time. The dsh
+ * default stops after 2 retries and caps scheduled delays at 10 seconds, so
+ * this provider retries longer and backs off further to ride out such a blip.
+ */
+export const OPENAI_CODEX_RETRY_POLICY = resolveRetryPolicy({
+  mode: 'normal',
+  maxRetries: 5,
+  backoff: { initialDelayMs: 1_000, maxDelayMs: 30_000, jitterRatio: 0.2 },
+}, 'dsh-openai-codex retryPolicy')
+
+/**
  * Give the generic dsh adapter a request-scoped bearer-token entry without
  * changing the provider's user-facing OAuth flow. The resolver accepts only
  * the explicit override supplied by this plugin; it never discovers an API
@@ -149,7 +161,7 @@ export function createOpenAICodexAdapter(
     provider: OPENAI_CODEX_PROVIDER,
     displayName: 'OpenAI Codex',
     streamIdleTimeoutMs: OPENAI_CODEX_STREAM_IDLE_TIMEOUT_MS,
-    retryPolicy: resolveRetryPolicy(undefined, 'dsh-openai-codex retryPolicy'),
+    retryPolicy: OPENAI_CODEX_RETRY_POLICY,
     configuredMaxTokens: new Map(),
     piProvider: responses.wrap(requestProvider(provider, fastMode)),
   }]])

--- a/src/auth-routes.ts
+++ b/src/auth-routes.ts
@@ -56,9 +56,19 @@ interface LoginChallenge {
   url: string
 }
 
-/** Testable timing boundary; production uses the exported 30-second ceiling. */
+/**
+ * Maximum time one browser-login operation may stay pending. The OAuth
+ * callback listener can otherwise wait forever (closed popup, callback lost
+ * to another listener, or sign-in completed through a different front door),
+ * which pins the public status at `signing-in` even when a valid credential
+ * is already stored.
+ */
+export const OPENAI_CODEX_SIGN_IN_TIMEOUT_MS = 10 * 60 * 1000
+
+/** Testable timing boundaries for the authorization URL and complete callback flow. */
 export interface OpenAICodexWebAuthOptions {
   challengeTimeoutMs?: number
+  signInTimeoutMs?: number
 }
 
 /** Redact provider diagnostics before they cross to the browser. */
@@ -88,14 +98,19 @@ export class OpenAICodexWebAuth {
   private challengeWaiters: Array<{ resolve(value: LoginChallenge): void; reject(error: unknown): void }> = []
   private challengeTimer: ReturnType<typeof setTimeout> | undefined
   private readonly challengeTimeoutMs: number
+  private readonly signInTimeoutMs: number
 
   constructor(
     private readonly store: OpenAICodexCredentialStore,
     options: OpenAICodexWebAuthOptions = {},
   ) {
     this.challengeTimeoutMs = options.challengeTimeoutMs ?? OPENAI_CODEX_AUTH_URL_TIMEOUT_MS
+    this.signInTimeoutMs = options.signInTimeoutMs ?? OPENAI_CODEX_SIGN_IN_TIMEOUT_MS
     if (!Number.isFinite(this.challengeTimeoutMs) || this.challengeTimeoutMs <= 0) {
       throw new TypeError('OpenAI Codex auth URL timeout must be a positive finite number')
+    }
+    if (!Number.isFinite(this.signInTimeoutMs) || this.signInTimeoutMs <= 0) {
+      throw new TypeError('OpenAI Codex sign-in timeout must be a positive finite number')
     }
   }
 
@@ -139,6 +154,10 @@ export class OpenAICodexWebAuth {
       this.cancelSignIn(new Error(`OpenAI Codex did not provide an authorization URL within ${String(this.challengeTimeoutMs)}ms`))
     }, this.challengeTimeoutMs)
     this.challengeTimer.unref()
+    const signInTimer = setTimeout(() => {
+      this.cancelSignIn(new Error('OpenAI Codex sign-in timed out waiting for the browser callback'))
+    }, this.signInTimeoutMs)
+    signInTimer.unref()
     this.operation = loginOpenAICodex({
       signal: cancellation.signal,
       prompt: prompt => prompt.type === 'select'
@@ -155,12 +174,22 @@ export class OpenAICodexWebAuth {
         }
         this.state = await this.readStoredStatus()
       },
-      (error: unknown) => {
+      async (error: unknown) => {
         this.rejectChallenge(error)
+        // A failed or abandoned browser flow must not mask a valid stored
+        // credential: sign-in may have completed through another front door.
+        try {
+          const stored = await this.readStoredStatus()
+          if (stored.status === 'signed-in') {
+            this.state = stored
+            return
+          }
+        } catch { /* fall through to the original error */ }
         this.state = { status: 'error', message: safeMessage(error) }
       },
     ).finally(() => {
       this.clearChallengeTimer()
+      clearTimeout(signInTimer)
       this.operation = undefined
       this.cancellation = undefined
     })

--- a/tests/adapter.spec.ts
+++ b/tests/adapter.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import type { OpenAICodexCredentialStore } from '../src/store.ts'
+import { OPENAI_CODEX_PROVIDER } from '../src/store.ts'
+import {
+  createOpenAICodexAdapter,
+  OPENAI_CODEX_RETRY_POLICY,
+} from '../src/adapter.ts'
+
+describe('OpenAI Codex adapter policy', () => {
+  it('registers the extended bounded retry policy on the provider route', () => {
+    const adapter = createOpenAICodexAdapter(
+      {} as OpenAICodexCredentialStore,
+      () => undefined,
+      () => ({ useWebSocketContextReuse: false, useNativeCompaction: false }),
+    )
+
+    expect(adapter.providerRetryPolicy(OPENAI_CODEX_PROVIDER)).toBe(OPENAI_CODEX_RETRY_POLICY)
+    expect(OPENAI_CODEX_RETRY_POLICY).toMatchObject({
+      mode: 'normal',
+      maxRetries: 5,
+      retryableCodes: expect.arrayContaining(['RATE_LIMIT', 'SERVER', 'TIMEOUT', 'TRANSPORT']),
+      initialDelayMs: 1_000,
+      maxDelayMs: 30_000,
+      jitterRatio: 0.2,
+    })
+  })
+})

--- a/tests/auth-routes.spec.ts
+++ b/tests/auth-routes.spec.ts
@@ -330,6 +330,45 @@ describe('OpenAI Codex Web OAuth boundary', () => {
     await auth.dispose()
   })
 
+  it('times out the complete browser callback flow after providing the auth URL', async () => {
+    let interaction: AuthInteraction | undefined
+    mocked.login.mockImplementation((next: AuthInteraction) => {
+      interaction = next
+      return abortableLogin(next)
+    })
+    const auth = new OpenAICodexWebAuth(store, {
+      challengeTimeoutMs: 1_000,
+      signInTimeoutMs: 5,
+    })
+    const challenge = auth.signIn()
+    if (interaction === undefined) throw new Error('login interaction was not captured')
+    interaction.notify({ type: 'auth_url', url: 'https://auth.openai.com/authorize' })
+
+    await expect(challenge).resolves.toEqual({ url: 'https://auth.openai.com/authorize' })
+    await vi.waitFor(() => { expect(interaction?.signal?.aborted).toBe(true) })
+    await auth.dispose()
+    await expect(auth.status()).resolves.toEqual({
+      status: 'error',
+      message: 'OpenAI Codex sign-in timed out waiting for the browser callback',
+    })
+  })
+
+  it('restores a valid stored credential after a failed browser flow', async () => {
+    mocked.login.mockRejectedValue(new Error('browser callback failed'))
+    mocked.status.mockResolvedValue({ authenticated: true })
+    mocked.usage.mockResolvedValue({ rateLimits: [] })
+    const auth = new OpenAICodexWebAuth(store)
+
+    await expect(auth.signIn()).rejects.toThrow(/browser callback failed/u)
+    await auth.dispose()
+
+    await expect(auth.status()).resolves.toEqual({
+      status: 'signed-in',
+      usage: { rateLimits: [] },
+    })
+    expect(mocked.status).toHaveBeenCalled()
+  })
+
   it('reports reauth-required without logging out or starting OAuth', async () => {
     mocked.status.mockResolvedValue({ authenticated: true })
     mocked.usage.mockRejectedValue(new OpenAICodexReauthRequiredError())


### PR DESCRIPTION
- auth-routes: cap browser-login wait at 10 minutes; when a login flow fails or times out, fall back to the stored credential before showing an error so a valid sign-in is never masked by a stale pending flow.
- adapter: retry up to 5 times with 1s-30s backoff so short proxy/TUN blips to chatgpt.com no longer abort the whole turn.