### PR TITLE
fix: supply image request budgets in the Codex provider profile

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -22,6 +22,21 @@ export function openAICodexModelCatalog(): readonly ModelCatalogEntry[] {
 /** Provider idle ceiling used by the composite route. */
 export const OPENAI_CODEX_STREAM_IDLE_TIMEOUT_MS = 300_000
 
+/**
+ * Image request budgets for the composite profile, mirroring the
+ * dsh-llm-pi-ai defaults. `ResolvedPiAiProviderProfile` gained these required
+ * fields after the dsh `0.1.0-rc.7` this package pins: newer hosts hand them
+ * to attachment policy validation, so an image-bearing request fails with
+ * `Image request maxPixels must be a positive integer` when they are absent,
+ * while older hosts ignore them. The spread keeps the profile literal free
+ * of excess-property errors against the pinned rc.7 types.
+ */
+const OPENAI_CODEX_IMAGE_REQUEST_BUDGETS = {
+  maxRequestImageBytes: 20 * 1024 * 1024,
+  requestImagePixelBudget: 2048 * 2048,
+  requestImageMaxBytes: 1024 * 1024,
+}
+
 function record(value: unknown): Record<string, unknown> | undefined {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
     ? value as Record<string, unknown>
@@ -178,6 +193,7 @@ export function createOpenAICodexAdapter(
     streamIdleTimeoutMs: OPENAI_CODEX_STREAM_IDLE_TIMEOUT_MS,
     retryPolicy: OPENAI_CODEX_RETRY_POLICY,
     configuredMaxTokens: new Map(),
+    ...OPENAI_CODEX_IMAGE_REQUEST_BUDGETS,
     piProvider: responses.wrap(requestProvider(provider, fastMode)),
   }]])
   const models: MutableModels = createModels({ credentials })


### PR DESCRIPTION
## Problem

On current dsh builds (post-`0.1.0-rc.7`), every Codex request that carries an image fails with:

```
Image request maxPixels must be a positive integer
```

Once a generated (`imagegen`) or pasted image enters the conversation history, **every** subsequent turn fails the same way and retrying never recovers — the session is stuck.

## Root cause

`ResolvedPiAiProviderProfile` gained three required fields after the `0.1.0-rc.7` this package pins:

- `maxRequestImageBytes`
- `requestImagePixelBudget`
- `requestImageMaxBytes`

`createOpenAICodexAdapter` builds the profile literal without them. At runtime on a newer host, `dsh-llm-pi-ai`'s adapter hands `profile.requestImagePixelBudget` (`undefined`) to the attachment store's `readImageRequest` policy validation, which throws. On the pinned rc.7 host nothing reads the fields, so the gap only shows up after a dsh upgrade.

## Fix

Supply the dsh-llm-pi-ai default budgets (20MiB request cap, 2048×2048 pixel budget, 1MiB raw cap) in the composite profile. The values are added through a spread so the literal stays free of excess-property errors against the pinned rc.7 types, while newer hosts pick them up at runtime.

## Verification

- `pnpm run check` (strict typecheck against rc.7, tests, both runtime bundles) passes
- Applied against a current dsh source checkout, an `imagegen` conversation that previously failed every turn now completes normally