### PR TITLE
fix: define Codex image request limits

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -22,6 +22,17 @@ export function openAICodexModelCatalog(): readonly ModelCatalogEntry[] {
 /** Provider idle ceiling used by the composite route. */
 export const OPENAI_CODEX_STREAM_IDLE_TIMEOUT_MS = 300_000
 
+/**
+ * Request-image limits required by current dsh-llm-pi-ai profiles.
+ * Keep these aligned with the adapter defaults: individual images are
+ * normalized to 2048² and 1 MiB, while the complete request may carry 20 MiB.
+ */
+export const OPENAI_CODEX_MAX_REQUEST_IMAGE_BYTES = 20 * 1024 * 1024
+export const OPENAI_CODEX_REQUEST_IMAGE_POLICY = Object.freeze({
+  maxPixels: 2048 * 2048,
+  maxBytes: 1024 * 1024,
+})
+
 function record(value: unknown): Record<string, unknown> | undefined {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
     ? value as Record<string, unknown>
@@ -172,14 +183,25 @@ export function createOpenAICodexAdapter(
 ): PiAiAdapter {
   const provider = openaiCodexProvider()
   const responses = new OpenAICodexResponseRuntime(responsePreferences)
-  const profiles = new Map<string, ResolvedPiAiProviderProfile>([[OPENAI_CODEX_PROVIDER, {
+  // rc.7 accepts these fields structurally but does not declare them yet;
+  // newer Harness releases require them. The intersection keeps one build
+  // compatible with both sides of that public-profile evolution.
+  const profile: ResolvedPiAiProviderProfile & {
+    maxRequestImageBytes: number
+    requestImagePixelBudget: number
+    requestImageMaxBytes: number
+  } = {
     provider: OPENAI_CODEX_PROVIDER,
     displayName: 'OpenAI Codex',
     streamIdleTimeoutMs: OPENAI_CODEX_STREAM_IDLE_TIMEOUT_MS,
+    maxRequestImageBytes: OPENAI_CODEX_MAX_REQUEST_IMAGE_BYTES,
+    requestImagePixelBudget: OPENAI_CODEX_REQUEST_IMAGE_POLICY.maxPixels,
+    requestImageMaxBytes: OPENAI_CODEX_REQUEST_IMAGE_POLICY.maxBytes,
     retryPolicy: OPENAI_CODEX_RETRY_POLICY,
     configuredMaxTokens: new Map(),
     piProvider: responses.wrap(requestProvider(provider, fastMode)),
-  }]])
+  }
+  const profiles = new Map<string, ResolvedPiAiProviderProfile>([[OPENAI_CODEX_PROVIDER, profile]])
   const models: MutableModels = createModels({ credentials })
   models.setProvider(provider)
   return new OpenAICodexAdapter({

--- a/tests/adapter.spec.ts
+++ b/tests/adapter.spec.ts
@@ -3,6 +3,8 @@ import type { OpenAICodexCredentialStore } from '../src/store.ts'
 import { OPENAI_CODEX_PROVIDER } from '../src/store.ts'
 import {
   createOpenAICodexAdapter,
+  OPENAI_CODEX_MAX_REQUEST_IMAGE_BYTES,
+  OPENAI_CODEX_REQUEST_IMAGE_POLICY,
   OPENAI_CODEX_RETRY_POLICY,
 } from '../src/adapter.ts'
 import { Config } from '../src/index.ts'
@@ -11,6 +13,17 @@ describe('OpenAI Codex adapter policy', () => {
   it('distinguishes an omitted model list from an explicitly empty list', () => {
     expect(Config({}).models).toBeUndefined()
     expect(Config({ models: [] }).models).toEqual([])
+  })
+
+  it('defines complete positive-integer request-image limits for the provider profile', () => {
+    expect(OPENAI_CODEX_MAX_REQUEST_IMAGE_BYTES).toBe(20 * 1024 * 1024)
+    expect(OPENAI_CODEX_REQUEST_IMAGE_POLICY).toEqual({
+      maxPixels: 2048 * 2048,
+      maxBytes: 1024 * 1024,
+    })
+    expect(Number.isSafeInteger(OPENAI_CODEX_MAX_REQUEST_IMAGE_BYTES)).toBe(true)
+    expect(Number.isSafeInteger(OPENAI_CODEX_REQUEST_IMAGE_POLICY.maxPixels)).toBe(true)
+    expect(Number.isSafeInteger(OPENAI_CODEX_REQUEST_IMAGE_POLICY.maxBytes)).toBe(true)
   })
 
   it('registers the extended bounded retry policy on the provider route', () => {


### PR DESCRIPTION
## Summary

- define complete request-image limits on the OpenAI Codex provider profile
- keep the profile compatible with both rc.7 and current dsh-llm-pi-ai types
- add regression coverage for positive integer image budgets

## Problem

Current DeepSeek Harness versions require ResolvedPiAiProviderProfile routes to provide maxRequestImageBytes, equestImagePixelBudget, and equestImageMaxBytes. Without them, sending an image through the Codex route reaches the attachment pipeline with maxPixels: undefined and fails with:

`	ext
Image request maxPixels must be a positive integer
`

## Validation

- pnpm run check
- 22 test files passed
- 155 tests passed
- typecheck and build passed