### PR TITLE
fix: discover models from the Codex CLI and Desktop cache

### DIFF
--- a/README.i18n.yaml
+++ b/README.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   git hash-object README.md README.zh.md
-README.md: 0059d44b6bbee67b3aa9ea5f0be330e0515781a5
-README.zh.md: 38ee466d25680cb443ee2955d69a85e14de09d8e
+README.md: f39dcd38601a530df4aeb9680719205f75e0b4db
+README.zh.md: d1f11b68c9085e10a264b323e101ce86e622d8e6

--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ The bundle selects `openai-codex` / `gpt-5.6-sol` for new agents and selects the
 
 ## Model catalog
 
+The plugin reads the Codex CLI/Desktop `models_cache.json` to discover models not yet bundled by pi-ai and update their names, input modalities, reasoning levels, and default `context_window`. It checks the file specified by `DSH_CODEX_MODELS_CACHE`, then `CODEX_HOME/models_cache.json`, then `~/.codex/models_cache.json`. Only valid entries with `visibility: list` are imported; the maximum expandable window does not replace the default capacity.
+
+Codex CLI/Desktop refreshes this cache. The plugin reads model metadata only, keeps its separate dsh OAuth login, never reads or copies Codex credentials, and does not launch a Codex subprocess. After updating and opening Codex, reopen the plugin's model settings or refresh the model list to discover changes. Missing, corrupt, or partially written caches retain the last usable catalog; a fresh start without a cache uses bundled models, including GPT-6 Astra. Catalog metadata does not guarantee model access for the account signed into dsh.
+
+Saved model selections are preserved. Enable newly discovered models in the settings below; a temporarily unavailable cache does not delete saved model IDs. Newly discovered models without bundled pricing use a zero cost estimate, which does not mean the model is free.
+
 By default, the model picker advertises the complete `openai-codex` catalog. Open **Settings → OpenAI Codex** and use the model checkboxes to choose which entries remain visible. The selection is live and durable; dsh refreshes the Web and TUI model directories after it changes.
 
 The same initial subset can be seeded through `models` on the `llm-openai-codex` entry while preserving provider order:

--- a/README.zh.md
+++ b/README.zh.md
@@ -58,6 +58,12 @@ bundle 会为新建 agent 选择 `openai-codex` / `gpt-5.6-sol`，并选择 Code
 
 ## 模型目录
 
+插件会读取 Codex CLI/Desktop 的 `models_cache.json`，补充 pi-ai 尚未收录的新模型，并使用缓存中的名称、输入能力、推理档位和默认 `context_window`。查找顺序为 `DSH_CODEX_MODELS_CACHE` 指定的文件、`CODEX_HOME/models_cache.json`、`~/.codex/models_cache.json`。只导入 `visibility: list` 的有效条目；缓存中声明的最大可扩展窗口不会自动替换默认容量。
+
+缓存由 Codex CLI/Desktop 刷新；本插件只读取模型元数据，仍使用独立的 dsh OAuth 登录，不读取或复制 Codex 凭据，也不依赖启动 Codex 子进程。更新 Codex 并打开一次后，再打开插件模型设置或刷新模型列表即可发现变化。缓存缺失、损坏或正在写入时保留最近可用目录；首次启动没有缓存时使用随包目录（含 GPT-6 Astra）。目录元数据不保证当前 dsh 登录账号拥有相应模型权限。
+
+已保存的模型选择会保留。新增模型可以在下面的设置中启用；缓存暂时不可用不会删除已保存的模型 ID。新发现模型若没有随包价格信息，用量价格估算为 0，不能把它理解为该模型免费。
+
 默认情况下，模型选择器会展示完整的 `openai-codex` 目录。打开 **设置 → OpenAI Codex**，通过模型复选框选择需要显示的条目。该选择实时生效并持久保存；修改后 dsh 会刷新 Web 与 TUI 的模型目录。
 
 也可以在 `llm-openai-codex` 条目上通过 `models` 设置初始子集，并保持提供方原有顺序：

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-codex",
   "description": "ChatGPT OAuth, Codex models, search, read_image URL support, and gpt-image-2 generation for DeepSeek Harness",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -39,9 +39,9 @@ const GPT_6_ASTRA = "gpt-6-astra";
 const OPENAI_CODEX_MODEL_ORDER = new Map<string, number>(
   [
     GPT_6_ASTRA,
-    "gpt-5.6-luna",
     "gpt-5.6-sol",
     "gpt-5.6-terra",
+    "gpt-5.6-luna",
     GPT_5_3_CODEX_SPARK,
     "gpt-5.5",
     "gpt-5.4",

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -31,6 +31,7 @@ import type {
   ResponseApiPreferences,
 } from "./tool-policy.ts";
 import type { FastModeRegistry } from "./fast-mode.ts";
+import { OpenAICodexModelCatalog } from "./model-catalog.ts";
 
 const GPT_5_3_CODEX_SPARK = "gpt-5.3-codex-spark";
 const GPT_6_ASTRA = "gpt-6-astra";
@@ -97,9 +98,18 @@ function withOpenAICodexModelAdditions(provider: Provider): Provider {
   };
 }
 
-/** Return a detached copy of the complete pi-ai Codex model catalog. */
-export function openAICodexModelCatalog(): readonly ModelCatalogEntry[] {
-  return withOpenAICodexModelAdditions(openaiCodexProvider())
+/** Keep bundled models as a fallback and discover new releases from Codex metadata. */
+export function createOpenAICodexModelProvider(): Provider {
+  const provider = withOpenAICodexModelAdditions(openaiCodexProvider());
+  const catalog = new OpenAICodexModelCatalog(provider.getModels());
+  return { ...provider, getModels: () => catalog.getModels() };
+}
+
+/** Return a detached copy of the current Codex model catalog for settings. */
+export function openAICodexModelCatalog(
+  provider: Provider = createOpenAICodexModelProvider()
+): readonly ModelCatalogEntry[] {
+  return provider
     .getModels()
     .map((model) => ({
       id: model.id,
@@ -484,10 +494,11 @@ export function createOpenAICodexAdapter(
   contextWindow?: () => number | null | undefined,
   overrideSparkContextWindow?: () => boolean | undefined,
   requestFetch?: FetchFunction,
-  fastModeDefault?: () => boolean
+  fastModeDefault?: () => boolean,
+  modelProvider: Provider = createOpenAICodexModelProvider()
 ): PiAiAdapter {
   const provider = requestProvider(
-    withOpenAICodexModelAdditions(openaiCodexProvider()),
+    modelProvider,
     fastMode,
     fastModeDefault,
     requestFetch
@@ -500,17 +511,20 @@ export function createOpenAICodexAdapter(
   let resolvedContextWindow: number | null | undefined | typeof unset = unset;
   let resolvedOverrideSparkContextWindow: boolean | undefined;
   let resolvedProfiles: Map<string, ResolvedPiAiProviderProfile> | undefined;
+  let resolvedModelCatalog: ReturnType<Provider["getModels"]> | undefined;
   const profiles = (): Map<string, ResolvedPiAiProviderProfile> => {
+    const nextModelCatalog = provider.getModels();
     const nextContextWindow = contextWindow?.();
     const nextOverrideSparkContextWindow = overrideSparkContextWindow?.();
     if (
       resolvedProfiles !== undefined &&
+      nextModelCatalog === resolvedModelCatalog &&
       nextContextWindow === resolvedContextWindow &&
       nextOverrideSparkContextWindow === resolvedOverrideSparkContextWindow
     )
       return resolvedProfiles;
     const configuredProvider = withOpenAICodexContextWindow(
-      provider,
+      { ...provider, getModels: () => nextModelCatalog },
       nextContextWindow,
       nextOverrideSparkContextWindow
     );
@@ -532,6 +546,7 @@ export function createOpenAICodexAdapter(
       piProvider: responses.wrap(configuredProvider),
     };
     resolvedContextWindow = nextContextWindow;
+    resolvedModelCatalog = nextModelCatalog;
     resolvedOverrideSparkContextWindow = nextOverrideSparkContextWindow;
     resolvedProfiles = new Map([[OPENAI_CODEX_PROVIDER, profile]]);
     return resolvedProfiles;

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import type {} from "@deepseek-ai/dsh-tools";
 import type {} from "@deepseek-ai/dsh-fs";
 import {
   createOpenAICodexAdapter,
+  createOpenAICodexModelProvider,
   openAICodexModelCatalog,
 } from "./adapter.ts";
 import { registerOpenAICodexAuthRoutes } from "./auth-routes.ts";
@@ -219,11 +220,12 @@ export const Config: z<Config> = z.object({
  */
 export function apply(ctx: Context, config: Config): void {
   installOpenAICodexSearchEvent();
+  const modelProvider = createOpenAICodexModelProvider();
   const service = new OpenAICodexService({
     ...(config.models === undefined ? {} : { models: config.models }),
     contextWindow: config.contextWindow ?? null,
     overrideSparkContextWindow: config.overrideSparkContextWindow ?? false,
-    modelCatalog: openAICodexModelCatalog(),
+    modelCatalog: () => openAICodexModelCatalog(modelProvider),
     modifyReadImage: config.modifyReadImage ?? true,
     shareImagegenWithOtherModels: config.shareImagegenWithOtherModels ?? true,
     useWebSocketContextReuse: config.useWebSocketContextReuse ?? false,
@@ -259,7 +261,8 @@ export function apply(ctx: Context, config: Config): void {
       () => imageTools.contextWindowSnapshot().contextWindow,
       () => imageTools.contextWindowSnapshot().overrideSparkContextWindow,
       service.proxy.fetch,
-      () => imageTools.fastModeSnapshot().fastModeDefault
+      () => imageTools.fastModeSnapshot().fastModeDefault,
+      modelProvider
     )
   );
   ctx.web.registerSearchProvider(

--- a/src/model-catalog.ts
+++ b/src/model-catalog.ts
@@ -1,0 +1,110 @@
+import { readFileSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { Api, Model, ThinkingLevelMap } from "@earendil-works/pi-ai";
+
+/** Only model metadata is shared with Codex; its credentials are never read. */
+export function openAICodexModelsCachePath(): string {
+  return process.env["DSH_CODEX_MODELS_CACHE"]?.trim() ||
+    join(process.env["CODEX_HOME"]?.trim() || join(homedir(), ".codex"), "models_cache.json");
+}
+
+function record(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown> : undefined;
+}
+
+function positiveInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}
+
+/** Merge picker-visible Codex metadata while preserving bundled transport and pricing. */
+export function mergeOpenAICodexModels(
+  bundled: readonly Model<Api>[],
+  document: unknown
+): readonly Model<Api>[] {
+  const entries = record(document)?.["models"];
+  const transport = bundled[0];
+  if (!Array.isArray(entries) || transport === undefined) return bundled;
+  const known = new Map(bundled.map(model => [model.id, model]));
+  const discovered = new Map<string, Model<Api>>();
+  for (const value of entries) {
+    const entry = record(value);
+    const id = entry?.["slug"];
+    const contextWindow = entry?.["context_window"];
+    if (!entry || entry["visibility"] !== "list" ||
+      typeof id !== "string" || !/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/.test(id) ||
+      !positiveInteger(contextWindow) || discovered.has(id)) continue;
+    const existing = known.get(id);
+    const modalities = entry["input_modalities"];
+    const input: ("text" | "image")[] = Array.isArray(modalities)
+      ? modalities.filter((item): item is "text" | "image" => item === "text" || item === "image")
+      : existing?.input ?? ["text", "image"];
+    if (!input.includes("text")) continue;
+    const levels = entry["supported_reasoning_levels"];
+    const efforts = Array.isArray(levels)
+      ? levels.flatMap(level => {
+        const effort = record(level)?.["effort"];
+        return typeof effort === "string" ? [effort] : [];
+      }) : undefined;
+    const thinkingLevelMap: ThinkingLevelMap = {};
+    if (efforts !== undefined) {
+      for (const level of ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const) {
+        thinkingLevelMap[level] = efforts.includes(level) ? level : null;
+      }
+      if (!efforts.includes("minimal") && efforts.includes("low")) thinkingLevelMap.minimal = "low";
+    }
+    discovered.set(id, {
+      ...(existing ?? {
+        id,
+        api: transport.api,
+        provider: transport.provider,
+        baseUrl: transport.baseUrl,
+        // Subscription usage has no discoverable per-token price. Do not copy
+        // an unrelated model's rates or its model-specific compatibility flags.
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      }),
+      name: typeof entry["display_name"] === "string" && entry["display_name"].trim()
+        ? entry["display_name"] : existing?.name ?? id,
+      contextWindow,
+      maxTokens: Math.min(existing?.maxTokens ?? 128_000, contextWindow),
+      input,
+      reasoning: efforts === undefined ? existing?.reasoning ?? true : efforts.length > 0,
+      ...(efforts === undefined ? {} : { thinkingLevelMap }),
+    });
+  }
+  if (discovered.size === 0) return bundled;
+  return [...discovered.values(), ...bundled.filter(model => !discovered.has(model.id))];
+}
+
+/** Reload changed metadata without invalidating in-flight request snapshots. */
+export class OpenAICodexModelCatalog {
+  private signature: string | undefined;
+  private current: readonly Model<Api>[];
+
+  constructor(
+    private readonly bundled: readonly Model<Api>[],
+    private readonly filename = openAICodexModelsCachePath()
+  ) {
+    this.current = bundled;
+  }
+
+  getModels(): readonly Model<Api>[] {
+    try {
+      const stat = statSync(this.filename);
+      if (!stat.isFile() || stat.size > 10 * 1024 * 1024) return this.current;
+      const signature = `${stat.ino}:${stat.size}:${stat.mtimeMs}:${stat.ctimeMs}`;
+      if (signature === this.signature) return this.current;
+      const document: unknown = JSON.parse(readFileSync(this.filename, "utf8").replace(/^\uFEFF/, ""));
+      const next = mergeOpenAICodexModels(this.bundled, document);
+      // A partial rewrite, unsupported schema, or empty response must not erase
+      // the last usable catalog. Try again when Codex replaces the file.
+      if (next !== this.bundled) this.current = next;
+      this.signature = signature;
+    } catch {
+      // Codex is optional. Missing, unreadable, and interrupted writes all
+      // fall back to the last good snapshot (initially the bundled catalog).
+    }
+    return this.current;
+  }
+}

--- a/src/model-catalog.ts
+++ b/src/model-catalog.ts
@@ -74,7 +74,11 @@ export function mergeOpenAICodexModels(
     });
   }
   if (discovered.size === 0) return bundled;
-  return [...discovered.values(), ...bundled.filter(model => !discovered.has(model.id))];
+  const bundledIds = new Set(bundled.map((model) => model.id));
+  return [
+    ...bundled.map((model) => discovered.get(model.id) ?? model),
+    ...[...discovered.values()].filter((model) => !bundledIds.has(model.id)),
+  ];
 }
 
 /** Reload changed metadata without invalidating in-flight request snapshots. */

--- a/src/service.ts
+++ b/src/service.ts
@@ -39,7 +39,7 @@ export interface OpenAICodexServiceOptions
     FastModePreferences,
     ProxyPreferences {
   models?: string[];
-  modelCatalog: readonly ModelCatalogEntry[];
+  modelCatalog: readonly ModelCatalogEntry[] | (() => readonly ModelCatalogEntry[]);
 }
 
 /**

--- a/src/tool-policy.ts
+++ b/src/tool-policy.ts
@@ -121,13 +121,22 @@ export class ImageToolPolicy {
   private scope: SettingsScope<OpenAICodexPreferences> | undefined;
   private readonly imageWatchers = new Set<() => void>();
   private readonly proxyWatchers = new Set<() => void>();
-  private readonly modelCatalog: readonly ModelCatalogEntry[];
+  private readonly resolveModelCatalog: () => readonly ModelCatalogEntry[];
+
+  private get modelCatalog(): readonly ModelCatalogEntry[] {
+    return this.resolveModelCatalog();
+  }
 
   constructor(
     base: Partial<OpenAICodexPreferences> = {},
-    modelCatalog: readonly ModelCatalogEntry[] = []
+    modelCatalog: readonly ModelCatalogEntry[] | (() => readonly ModelCatalogEntry[]) = []
   ) {
-    this.modelCatalog = modelCatalog.map((model) => ({ ...model }));
+    if (typeof modelCatalog === "function") {
+      this.resolveModelCatalog = modelCatalog;
+    } else {
+      const initialCatalog = modelCatalog.map((model) => ({ ...model }));
+      this.resolveModelCatalog = () => initialCatalog;
+    }
     this.current = {
       ...DEFAULT_IMAGE_TOOL_PREFERENCES,
       ...DEFAULT_RESPONSE_API_PREFERENCES,
@@ -136,9 +145,9 @@ export class ImageToolPolicy {
       ...DEFAULT_PROXY_PREFERENCES,
       useStatefulResponses: false,
       ...base,
-      models: this.normalizeModels(
+      models: [...(
         base.models ?? this.modelCatalog.map((model) => model.id)
-      ),
+      )],
     };
     if (
       this.current.useStatefulResponses &&
@@ -292,7 +301,7 @@ export class ImageToolPolicy {
   modelCatalogSnapshot(): ModelCatalogSettings {
     return {
       availableModels: this.modelCatalog.map((model) => ({ ...model })),
-      models: [...this.current.models],
+      models: this.normalizeModels(this.current.models),
     };
   }
 
@@ -325,7 +334,9 @@ export class ImageToolPolicy {
       next.useStatefulResponses && !next.useWebSocketContextReuse
         ? { ...next, useWebSocketContextReuse: true }
         : next;
-    next = { ...next, models: this.normalizeModels(next.models) };
+    // Keep saved ids if the optional Codex cache is temporarily unavailable.
+    // Discovery filters against the current catalog without deleting preferences.
+    next = { ...next, models: [...next.models] };
     const imageChanged =
       next.modifyReadImage !== this.current.modifyReadImage ||
       next.shareImagegenWithOtherModels !==

--- a/src/tool-policy.ts
+++ b/src/tool-policy.ts
@@ -312,7 +312,16 @@ export class ImageToolPolicy {
     if (this.scope === undefined)
       throw new Error("OpenAI Codex settings service is unavailable");
     if (patch.models === undefined) return this.modelCatalogSnapshot();
-    await this.scope.update({ models: this.normalizeModels(patch.models) });
+    const availableIds = new Set(this.modelCatalog.map((model) => model.id));
+    const unavailableSelections = [
+      ...new Set(this.current.models.filter((id) => !availableIds.has(id))),
+    ];
+    await this.scope.update({
+      models: [
+        ...this.normalizeModels(patch.models),
+        ...unavailableSelections,
+      ],
+    });
     this.replace(this.scope.get());
     return this.modelCatalogSnapshot();
   }

--- a/tests/adapter.spec.ts
+++ b/tests/adapter.spec.ts
@@ -177,8 +177,8 @@ describe("OpenAI Codex adapter policy", () => {
 
     const models = await adapter.listModels(OPENAI_CODEX_PROVIDER);
     expect(models.map((model) => model.id)).toEqual([
-      "gpt-5.6-luna",
       "gpt-5.6-terra",
+      "gpt-5.6-luna",
     ]);
 
     await expect(
@@ -268,9 +268,9 @@ describe("OpenAI Codex adapter policy", () => {
     const catalog = openAICodexModelCatalog();
     expect(catalog.map((model) => model.id)).toEqual([
       "gpt-6-astra",
-      "gpt-5.6-luna",
       "gpt-5.6-sol",
       "gpt-5.6-terra",
+      "gpt-5.6-luna",
       "gpt-5.3-codex-spark",
       "gpt-5.5",
       "gpt-5.4",

--- a/tests/model-catalog.spec.ts
+++ b/tests/model-catalog.spec.ts
@@ -35,15 +35,21 @@ describe("Codex model discovery", () => {
       { ...astra, baseUrl: "https://untrusted.invalid", headers: { Authorization: "untrusted" } },
       { ...astra, slug: "gpt-future-model", input_modalities: ["text"] },
     ] });
-    expect(models[0]).toMatchObject({
+    const astraModel = models.find((model) => model.id === "gpt-6-astra");
+    expect(astraModel).toMatchObject({
       id: "gpt-6-astra", name: "GPT-6-Astra", contextWindow: 272_000,
       maxTokens: 128_000, input: ["text", "image"],
       baseUrl: "https://chatgpt.com/backend-api", provider: "openai-codex",
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
       thinkingLevelMap: { minimal: "low", medium: null, max: "max" },
     });
-    expect(models[0]?.headers).toBeUndefined();
-    expect(models[1]).toMatchObject({ id: "gpt-future-model", input: ["text"] });
+    expect(astraModel?.headers).toBeUndefined();
+    expect(models.find((model) => model.id === "gpt-future-model"))
+      .toMatchObject({ id: "gpt-future-model", input: ["text"] });
+    expect(models.slice(0, bundled.length).map((model) => model.id))
+      .toEqual(bundled.map((model) => model.id));
+    expect(models.slice(bundled.length).map((model) => model.id))
+      .toEqual(["gpt-6-astra", "gpt-future-model"]);
     expect(models.some(model => model.id === "gpt-5.4")).toBe(true);
   });
 
@@ -56,8 +62,39 @@ describe("Codex model discovery", () => {
       { ...astra, slug: "gpt-5.6-sol", context_window: 999 },
     ] });
     expect(models).toHaveLength(bundled.length);
-    expect(models[0]?.contextWindow).toBe(272_000);
-    expect(models[0]?.cost).toEqual(bundled.find(model => model.id === "gpt-5.6-sol")?.cost);
+    const sol = models.find((model) => model.id === "gpt-5.6-sol");
+    expect(sol?.contextWindow).toBe(272_000);
+    expect(sol?.cost).toEqual(bundled.find(model => model.id === "gpt-5.6-sol")?.cost);
+  });
+
+  it("keeps the curated model order and appends unknown cache entries stably", () => {
+    const filename = cacheFile();
+    vi.stubEnv("DSH_CODEX_MODELS_CACHE", filename);
+    writeCache(filename, [
+      astra,
+      { ...astra, slug: "gpt-5.6-sol" },
+      { ...astra, slug: "gpt-future-b" },
+      { ...astra, slug: "gpt-5.6-terra" },
+      { ...astra, slug: "gpt-5.6-luna" },
+      { ...astra, slug: "gpt-5.5" },
+      { ...astra, slug: "gpt-5.4-mini" },
+      { ...astra, slug: "gpt-5.3-codex-spark", input_modalities: ["text"] },
+      { ...astra, slug: "gpt-future-a" },
+    ]);
+
+    expect(createOpenAICodexModelProvider().getModels().map((model) => model.id))
+      .toEqual([
+        "gpt-6-astra",
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "gpt-5.6-luna",
+        "gpt-5.3-codex-spark",
+        "gpt-5.5",
+        "gpt-5.4",
+        "gpt-5.4-mini",
+        "gpt-future-b",
+        "gpt-future-a",
+      ]);
   });
 
   it("uses explicit cache paths before CODEX_HOME and the user default", () => {
@@ -74,7 +111,8 @@ describe("Codex model discovery", () => {
     expect(catalog.getModels()).toBe(bundled);
     writeFileSync(filename, '\uFEFF' + JSON.stringify({ models: [astra] }));
     const first = catalog.getModels();
-    expect(first[0]?.id).toBe("gpt-6-astra");
+    expect(first.find((model) => model.id === "gpt-6-astra")?.contextWindow)
+      .toBe(272_000);
     expect(catalog.getModels()).toBe(first);
     writeFileSync(filename, "{");
     expect(catalog.getModels()).toBe(first);
@@ -83,8 +121,10 @@ describe("Codex model discovery", () => {
     rmSync(filename);
     expect(catalog.getModels()).toBe(first);
     writeCache(filename, [{ ...astra, context_window: 512_000 }]);
-    expect(catalog.getModels()[0]?.contextWindow).toBe(512_000);
-    expect(first[0]?.contextWindow).toBe(272_000);
+    expect(catalog.getModels().find((model) => model.id === "gpt-6-astra")?.contextWindow)
+      .toBe(512_000);
+    expect(first.find((model) => model.id === "gpt-6-astra")?.contextWindow)
+      .toBe(272_000);
   });
 
   it("shares updates between settings and actual request resolution without changing prepared calls", async () => {

--- a/tests/model-catalog.spec.ts
+++ b/tests/model-catalog.spec.ts
@@ -1,0 +1,115 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { openaiCodexProvider } from "@earendil-works/pi-ai/providers/openai-codex";
+import { OpenAICodexModelCatalog, mergeOpenAICodexModels, openAICodexModelsCachePath } from "../src/model-catalog.ts";
+import { createOpenAICodexAdapter, createOpenAICodexModelProvider, openAICodexModelCatalog } from "../src/adapter.ts";
+import { ImageToolPolicy } from "../src/tool-policy.ts";
+import type { OpenAICodexCredentialStore } from "../src/store.ts";
+
+const bundled = openaiCodexProvider().getModels();
+const astra = {
+  slug: "gpt-6-astra", display_name: "GPT-6-Astra", visibility: "list",
+  context_window: 272_000, max_context_window: 872_000,
+  input_modalities: ["text", "image"],
+  supported_reasoning_levels: [{ effort: "low" }, { effort: "high" }, { effort: "max" }],
+};
+const directories: string[] = [];
+function cacheFile() {
+  const directory = mkdtempSync(join(tmpdir(), "dsh-codex-models-"));
+  directories.push(directory);
+  return join(directory, "models_cache.json");
+}
+function writeCache(filename: string, models: unknown[]) {
+  writeFileSync(filename, JSON.stringify({ models }));
+}
+afterEach(() => {
+  vi.unstubAllEnvs();
+  for (const directory of directories.splice(0)) rmSync(directory, { recursive: true, force: true });
+});
+
+describe("Codex model discovery", () => {
+  it("imports new models and capacities without inheriting another model's pricing or endpoint", () => {
+    const models = mergeOpenAICodexModels(bundled, { models: [
+      { ...astra, baseUrl: "https://untrusted.invalid", headers: { Authorization: "untrusted" } },
+      { ...astra, slug: "gpt-future-model", input_modalities: ["text"] },
+    ] });
+    expect(models[0]).toMatchObject({
+      id: "gpt-6-astra", name: "GPT-6-Astra", contextWindow: 272_000,
+      maxTokens: 128_000, input: ["text", "image"],
+      baseUrl: "https://chatgpt.com/backend-api", provider: "openai-codex",
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      thinkingLevelMap: { minimal: "low", medium: null, max: "max" },
+    });
+    expect(models[0]?.headers).toBeUndefined();
+    expect(models[1]).toMatchObject({ id: "gpt-future-model", input: ["text"] });
+    expect(models.some(model => model.id === "gpt-5.4")).toBe(true);
+  });
+
+  it("ignores hidden, malformed, and duplicate entries and preserves known model prices", () => {
+    const models = mergeOpenAICodexModels(bundled, { models: [
+      null, { ...astra, slug: "hidden", visibility: "hide" },
+      { ...astra, slug: "invalid", context_window: -1 },
+      { ...astra, slug: "image-only", input_modalities: ["image"] },
+      { ...astra, slug: "gpt-5.6-sol" },
+      { ...astra, slug: "gpt-5.6-sol", context_window: 999 },
+    ] });
+    expect(models).toHaveLength(bundled.length);
+    expect(models[0]?.contextWindow).toBe(272_000);
+    expect(models[0]?.cost).toEqual(bundled.find(model => model.id === "gpt-5.6-sol")?.cost);
+  });
+
+  it("uses explicit cache paths before CODEX_HOME and the user default", () => {
+    vi.stubEnv("DSH_CODEX_MODELS_CACHE", "");
+    vi.stubEnv("CODEX_HOME", join(tmpdir(), "custom codex"));
+    expect(openAICodexModelsCachePath()).toBe(join(tmpdir(), "custom codex", "models_cache.json"));
+    vi.stubEnv("DSH_CODEX_MODELS_CACHE", join(tmpdir(), "custom cache.json"));
+    expect(openAICodexModelsCachePath()).toBe(join(tmpdir(), "custom cache.json"));
+  });
+
+  it("reloads replacements while retaining the last usable snapshot during missing or corrupt writes", () => {
+    const filename = cacheFile();
+    const catalog = new OpenAICodexModelCatalog(bundled, filename);
+    expect(catalog.getModels()).toBe(bundled);
+    writeFileSync(filename, '\uFEFF' + JSON.stringify({ models: [astra] }));
+    const first = catalog.getModels();
+    expect(first[0]?.id).toBe("gpt-6-astra");
+    expect(catalog.getModels()).toBe(first);
+    writeFileSync(filename, "{");
+    expect(catalog.getModels()).toBe(first);
+    writeCache(filename, []);
+    expect(catalog.getModels()).toBe(first);
+    rmSync(filename);
+    expect(catalog.getModels()).toBe(first);
+    writeCache(filename, [{ ...astra, context_window: 512_000 }]);
+    expect(catalog.getModels()[0]?.contextWindow).toBe(512_000);
+    expect(first[0]?.contextWindow).toBe(272_000);
+  });
+
+  it("shares updates between settings and actual request resolution without changing prepared calls", async () => {
+    const filename = cacheFile();
+    vi.stubEnv("DSH_CODEX_MODELS_CACHE", filename);
+    writeCache(filename, [astra]);
+    const provider = createOpenAICodexModelProvider();
+    const policy = new ImageToolPolicy(
+      { models: ["gpt-6-astra", "gpt-future-model"] },
+      () => openAICodexModelCatalog(provider)
+    );
+    const adapter = createOpenAICodexAdapter(
+      {} as OpenAICodexCredentialStore, () => undefined,
+      () => ({ useWebSocketContextReuse: false, useNativeCompaction: false }),
+      undefined, () => policy.modelCatalogSnapshot().models,
+      undefined, undefined, undefined, undefined, provider
+    );
+    const first = await adapter.prepareCall("openai-codex", "gpt-6-astra");
+    expect(first.model.context?.contextWindow).toBe(272_000);
+    expect(policy.modelCatalogSnapshot().models).toEqual(["gpt-6-astra"]);
+    writeCache(filename, [{ ...astra, context_window: 512_000 }, { ...astra, slug: "gpt-future-model" }]);
+    expect(policy.modelCatalogSnapshot().models).toEqual(["gpt-6-astra", "gpt-future-model"]);
+    expect((await adapter.listModels("openai-codex")).map(model => model.id)).toEqual(["gpt-6-astra", "gpt-future-model"]);
+    expect((await adapter.resolveModel("openai-codex", "gpt-future-model")).context?.contextWindow).toBe(272_000);
+    expect((await adapter.prepareCall("openai-codex", "gpt-6-astra")).model.context?.contextWindow).toBe(512_000);
+    expect(first.model.context?.contextWindow).toBe(272_000);
+  });
+});

--- a/tests/tool-policy.spec.ts
+++ b/tests/tool-policy.spec.ts
@@ -168,6 +168,30 @@ describe("ImageToolPolicy", () => {
     expect(policy.modelCatalogSnapshot().models).toEqual(["gpt-5.6-sol"]);
   });
 
+  it("preserves selected model ids while they are temporarily unavailable", async () => {
+    const ctx = new Context();
+    context = ctx;
+    await ctx.plugin(MemorySettings);
+    let catalog = [
+      { id: "gpt-current", name: "GPT Current", contextWindow: 272_000 },
+    ];
+    const policy = new ImageToolPolicy(
+      { models: ["gpt-current", "gpt-future"] },
+      () => catalog
+    );
+    policy.attach(ctx);
+
+    expect(policy.modelCatalogSnapshot().models).toEqual(["gpt-current"]);
+    await policy.updateModelCatalog({ models: [] });
+    expect(policy.modelCatalogSnapshot().models).toEqual([]);
+
+    catalog = [
+      ...catalog,
+      { id: "gpt-future", name: "GPT Future", contextWindow: 272_000 },
+    ];
+    expect(policy.modelCatalogSnapshot().models).toEqual(["gpt-future"]);
+  });
+
   it("defaults an older partial settings document to the complete model catalog", async () => {
     const ctx = new Context();
     context = ctx;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vitest/config'
 
 const packageVersion = (JSON.parse(
@@ -10,6 +11,8 @@ export default defineConfig({
     __CODEX_CONNECT_VERSION__: JSON.stringify(packageVersion),
   },
   test: {
+    // Do not let a developer's installed Codex catalog affect bundled-model tests.
+    env: { DSH_CODEX_MODELS_CACHE: fileURLToPath(new URL('./tests/fixtures/no-codex-cache.json', import.meta.url)) },
     include: ['tests/**/*.spec.{ts,tsx}'],
     testTimeout: 30_000,
   },


### PR DESCRIPTION
New Codex releases are missing from pi-ai's bundled catalog, and manually adding each release leaves model discovery and context metadata behind Codex CLI/Desktop. Read picker-visible entries from `models_cache.json` and share the resulting catalog between settings and the request adapter, so newly released models can be selected and resolved without another hardcoded addition.

The cache path supports `DSH_CODEX_MODELS_CACHE`, `CODEX_HOME`, and the default user directory. Changed metadata creates a new adapter snapshot while prepared calls retain their original model configuration. Missing, malformed, or partially written caches retain the last usable catalog, with the existing bundled models as the initial fallback. Saved selections and temporarily unavailable model IDs are preserved. Only model metadata is imported; OAuth credentials and transport endpoints stay under the plugin's control.

Validation: `pnpm run check` passed (24 test files, 178 tests, both TypeScript projects, and build). Added regression coverage for unknown future model IDs, modalities and reasoning metadata, malformed/hidden/duplicate entries, cache replacements, settings discovery, actual adapter resolution, and prepared-call stability. Also verified the local Codex cache discovers `gpt-6-astra` with its Codex default context capacity of 272,000 tokens. This validates discovery and request preparation; it does not send a paid model generation request.

Codex CLI/Desktop remains responsible for refreshing its cache. Existing explicit model selections are preserved, so new entries can be enabled in Settings. No new dependency is required.
