### PR TITLE
fix: avoid read_image shadow race during unload

### DIFF
--- a/src/read-image-enhancement.ts
+++ b/src/read-image-enhancement.ts
@@ -1,6 +1,6 @@
 /** Optional HTTP(S) input for Harness's existing `read_image` tool. */
 
-import type { Context } from '@deepseek-ai/cordis'
+import { CordisError, type Context } from '@deepseek-ai/cordis'
 import { AttachmentId } from '@deepseek-ai/dsh-attachment'
 import type { ImageAttachmentRef, ImageMediaType } from '@deepseek-ai/dsh-attachment'
 import type { Agent } from '@deepseek-ai/dsh-agent'
@@ -198,7 +198,13 @@ export function installReadImageEnhancement(
     // layer; registering into agent.ctx then shadows either form uniformly.
     const original = ctx.tools.get(READ_IMAGE_TOOL_NAME, agent)
     if (original === undefined) return
-    const dispose = agent.ctx.tools.register(enhancedReadImageTool(ctx, original, publicHttpRuntime))
+    let dispose: () => void
+    try {
+      dispose = agent.ctx.tools.register(enhancedReadImageTool(ctx, original, publicHttpRuntime))
+    } catch (error: unknown) {
+      if (error instanceof CordisError && error.code === 'INACTIVE_EFFECT') return
+      throw error
+    }
     installed.set(agent, { original, dispose })
   }
 

--- a/tests/read-image-enhancement.spec.ts
+++ b/tests/read-image-enhancement.spec.ts
@@ -2,7 +2,7 @@ import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { Context } from '@deepseek-ai/cordis'
+import { Context, CordisError } from '@deepseek-ai/cordis'
 import LocalAttachmentStore from '@deepseek-ai/dsh-attachment-local'
 import LocalFileSystem from '@deepseek-ai/dsh-fs-local'
 import { CallId, LlmRuntime } from '@deepseek-ai/dsh-llm'
@@ -177,6 +177,56 @@ describe('read_image enhancement', () => {
     expect(root.tools.get('read_image', agent as never)?.description).toContain('HTTP(S) URL')
     cleanup?.()
     expect(root.tools.get('read_image', agent as never)).toBe(second)
+  })
+
+  it('does not recreate the scoped shadow while the agent context unloads', () => {
+    const root = {} as Context
+    const inherited = baseReadImage(root)
+    let agentActive = true
+    let scoped: ReturnType<typeof enhancedReadImageTool> | undefined
+    let toolsChanged: (() => void) | undefined
+    let disposeScoped: (() => void) | undefined
+    let registrations = 0
+    const agent = {
+      id: 'unloading-agent',
+      ctx: {
+        tools: {
+          register(definition: ReturnType<typeof enhancedReadImageTool>) {
+            if (!agentActive) throw new CordisError('INACTIVE_EFFECT')
+            registrations += 1
+            scoped = definition
+            let disposed = false
+            return disposeScoped = () => {
+              if (disposed) return
+              disposed = true
+              scoped = undefined
+              toolsChanged?.()
+            }
+          },
+        },
+      },
+    }
+    Object.assign(root, {
+      tools: {
+        get: (_name: string, scope?: object) => scope === agent ? scoped ?? inherited : undefined,
+      },
+      agents: {
+        list: () => [agent],
+        get: (id: string) => id === agent.id ? agent : undefined,
+      },
+      on: (name: string, listener: () => void) => {
+        if (name === 'tools/change') toolsChanged = listener
+        return () => undefined
+      },
+      effect: (effect: () => () => void) => effect(),
+    })
+
+    installReadImageEnhancement(root, new ImageToolPolicy())
+    expect(registrations).toBe(1)
+
+    agentActive = false
+    expect(() => { disposeScoped?.() }).not.toThrow()
+    expect(registrations).toBe(1)
   })
 
   it('advertises separate local-path and HTTP(S) URL inputs', async () => {


### PR DESCRIPTION
## Summary
- ignore Cordis `INACTIVE_EFFECT` when the `read_image` enhancement races with agent-context teardown
- preserve propagation of unexpected registration errors
- add a regression test covering a `tools/change` event emitted while the agent context is unloading

## Validation
- `npm exec -- vitest run tests/read-image-enhancement.spec.ts` (7 passed)
- `npm exec -- tsc -p tsconfig.json && npm exec -- tsc -p tsconfig.client.json`
- `npm exec -- tsdown`

## Test-suite note
The full Vitest run completed 139 tests successfully, including this regression test, but three unrelated client TSX suites failed during collection with Rolldown `Unexpected JSX expression` parse errors.