### PR TITLE
fix: supply modelErrors in resolved profile for DSH 0.1.5-rc.1

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -262,6 +262,7 @@ type ImageCompatibleResolvedPiAiProviderProfile =
     maxRequestImageBytes: number;
     requestImagePixelBudget: number;
     requestImageMaxBytes: number;
+    modelErrors: ReadonlyMap<string, string>;
   };
 
 function record(value: unknown): Record<string, unknown> | undefined {
@@ -543,6 +544,7 @@ export function createOpenAICodexAdapter(
       requestImageMaxBytes: OPENAI_CODEX_PROMPT_IMAGE_INPUT_GUARD_BYTES,
       retryPolicy: OPENAI_CODEX_RETRY_POLICY,
       configuredMaxTokens: new Map(),
+      modelErrors: new Map(),
       piProvider: responses.wrap(configuredProvider),
     };
     resolvedContextWindow = nextContextWindow;


### PR DESCRIPTION
## Problem

DSH `0.1.5-rc.1` made `ResolvedPiAiProviderProfile.modelErrors` a required field. `dsh-llm-pi-ai`'s `modelOf()` reads `profile.modelErrors.get(model)`, so a profile that omits it throws on the first model resolution or stream:

```
TypeError: Cannot read properties of undefined (reading 'get')
```

This breaks the `openai-codex` route on any Harness newer than `0.1.1-rc.2`.

## Change

Supply the required empty map in the resolved profile, and add the field to the local `ImageCompatibleResolvedPiAiProviderProfile` type so the build still type-checks against the pinned `0.1.1-rc.2` devDependency (where the field does not yet exist) while satisfying `0.1.5-rc.1`.

## Test plan

`pnpm run check`

---

This fix and pull request was created through DeepSeek. Its been designed to be as minimal as possible and already works locally.
